### PR TITLE
Release v1.1.3 - overall test coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Tests
+- Adicionados testes unitários para `UserService` e `RecurringTransactionService`, ampliando a cobertura geral do projeto.
+
 ## v1.1.2
 - Configuração de CORS com origem permitida por propriedade
 - Configuração local do SonarQube via Docker

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -218,6 +218,38 @@ class RecurringTransactionServiceTest {
 
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
+
+        @Test
+        @DisplayName("deve lancar erro quando data final for anterior a data inicial ao criar")
+        void shouldThrowWhenEndDateIsBeforeStartDateOnCreate() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            CreateRecurringTransactionRequest request = new CreateRecurringTransactionRequest(
+                    "Aluguel",
+                    new BigDecimal("1200.00"),
+                    TransactionType.EXPENSE,
+                    SourceType.WEB,
+                    RecurrenceFrequency.MONTHLY,
+                    LocalDate.of(2026, 4, 10),
+                    LocalDate.of(2026, 4, 1),
+                    ACCOUNT_ID,
+                    CATEGORY_ID
+            );
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+
+            assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("End date cannot be before start date");
+
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
     }
 
     @Nested
@@ -422,6 +454,98 @@ class RecurringTransactionServiceTest {
                     .hasMessage("Category type does not match transaction type");
 
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando data final for anterior a data inicial ao atualizar")
+        void shouldThrowWhenEndDateIsBeforeStartDateOnUpdate() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+
+            UpdateRecurringTransactionRequest request = new UpdateRecurringTransactionRequest(
+                    "Internet",
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    SourceType.WEB,
+                    RecurrenceFrequency.MONTHLY,
+                    LocalDate.of(2026, 5, 10),
+                    LocalDate.of(2026, 5, 1),
+                    ACCOUNT_ID,
+                    CATEGORY_ID,
+                    true
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+
+            assertThatThrownBy(() -> recurringTransactionService.update(RECURRING_TRANSACTION_ID, request, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("End date cannot be before start date");
+
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+
+        @Test
+        @DisplayName("deve desativar transacao recorrente ao atualizar active como falso")
+        void shouldDeactivateRecurringTransactionWhenUpdatingActiveToFalse() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setActive(true);
+
+            UpdateRecurringTransactionRequest request = new UpdateRecurringTransactionRequest(
+                    "Internet",
+                    new BigDecimal("150.00"),
+                    TransactionType.EXPENSE,
+                    SourceType.WEB,
+                    RecurrenceFrequency.MONTHLY,
+                    LocalDate.of(2026, 5, 1),
+                    LocalDate.of(2026, 12, 1),
+                    ACCOUNT_ID,
+                    CATEGORY_ID,
+                    false
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.update(
+                    RECURRING_TRANSACTION_ID,
+                    request,
+                    authentication
+            );
+
+            assertThat(response.active()).isFalse();
+            assertThat(recurringTransaction.isActive()).isFalse();
+
+            verify(recurringTransactionRepository).save(recurringTransaction);
         }
     }
 

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -1,0 +1,681 @@
+package com.financebot.recurring.service;
+
+import com.financebot.account.domain.Account;
+import com.financebot.account.domain.AccountType;
+import com.financebot.account.repository.AccountRepository;
+import com.financebot.category.domain.Category;
+import com.financebot.category.domain.CategoryType;
+import com.financebot.category.repository.CategoryRepository;
+import com.financebot.recurring.domain.RecurrenceFrequency;
+import com.financebot.recurring.domain.RecurringTransaction;
+import com.financebot.recurring.dto.request.CreateRecurringTransactionRequest;
+import com.financebot.recurring.dto.request.UpdateRecurringTransactionRequest;
+import com.financebot.recurring.dto.response.RecurringTransactionResponse;
+import com.financebot.recurring.repository.RecurringTransactionRepository;
+import com.financebot.transaction.domain.SourceType;
+import com.financebot.transaction.domain.TransactionType;
+import com.financebot.user.domain.User;
+import com.financebot.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RecurringTransactionServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long ACCOUNT_ID = 10L;
+    private static final Long CATEGORY_ID = 20L;
+    private static final Long RECURRING_TRANSACTION_ID = 100L;
+
+    @Mock
+    private RecurringTransactionRepository recurringTransactionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private RecurringTransactionService recurringTransactionService;
+
+    @Nested
+    @DisplayName("create")
+    class CreateTests {
+
+        @Test
+        @DisplayName("deve criar transacao recorrente com sucesso")
+        void shouldCreateRecurringTransactionSuccessfully() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            CreateRecurringTransactionRequest request = buildCreateRequest();
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+            when(recurringTransactionRepository.save(any(RecurringTransaction.class)))
+                    .thenAnswer(invocation -> {
+                        RecurringTransaction recurringTransaction = invocation.getArgument(0);
+                        recurringTransaction.setId(RECURRING_TRANSACTION_ID);
+                        return recurringTransaction;
+                    });
+
+            RecurringTransactionResponse response = recurringTransactionService.create(request, authentication);
+
+            assertThat(response.id()).isEqualTo(RECURRING_TRANSACTION_ID);
+            assertThat(response.description()).isEqualTo("Aluguel");
+            assertThat(response.amount()).isEqualByComparingTo("1200.00");
+            assertThat(response.type()).isEqualTo(TransactionType.EXPENSE);
+            assertThat(response.sourceType()).isEqualTo(SourceType.WEB);
+            assertThat(response.frequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
+            assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+            assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+            assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+            assertThat(response.active()).isTrue();
+            assertThat(response.accountId()).isEqualTo(ACCOUNT_ID);
+            assertThat(response.categoryId()).isEqualTo(CATEGORY_ID);
+
+            ArgumentCaptor<RecurringTransaction> captor = ArgumentCaptor.forClass(RecurringTransaction.class);
+            verify(recurringTransactionRepository).save(captor.capture());
+
+            RecurringTransaction saved = captor.getValue();
+
+            assertThat(saved.getDescription()).isEqualTo("Aluguel");
+            assertThat(saved.getAmount()).isEqualByComparingTo("1200.00");
+            assertThat(saved.getType()).isEqualTo(TransactionType.EXPENSE);
+            assertThat(saved.getSourceType()).isEqualTo(SourceType.WEB);
+            assertThat(saved.getFrequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
+            assertThat(saved.getStartDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+            assertThat(saved.getEndDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+            assertThat(saved.getNextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+            assertThat(saved.isActive()).isTrue();
+            assertThat(saved.getUser()).isEqualTo(user);
+            assertThat(saved.getAccount()).isEqualTo(account);
+            assertThat(saved.getCategory()).isEqualTo(category);
+        }
+
+        @Test
+        @DisplayName("deve remover espacos da descricao ao criar")
+        void shouldTrimDescriptionWhenCreating() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            CreateRecurringTransactionRequest request = new CreateRecurringTransactionRequest(
+                    "  Academia  ",
+                    new BigDecimal("99.90"),
+                    TransactionType.EXPENSE,
+                    SourceType.WEB,
+                    RecurrenceFrequency.MONTHLY,
+                    LocalDate.of(2026, 4, 1),
+                    LocalDate.of(2026, 12, 1),
+                    ACCOUNT_ID,
+                    CATEGORY_ID
+            );
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+            when(recurringTransactionRepository.save(any(RecurringTransaction.class)))
+                    .thenAnswer(invocation -> invocation.getArgument(0));
+
+            RecurringTransactionResponse response = recurringTransactionService.create(request, authentication);
+
+            assertThat(response.description()).isEqualTo("Academia");
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria nao combinar com tipo da transacao")
+        void shouldThrowWhenCategoryDoesNotMatchTransactionTypeOnCreate() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.INCOME);
+
+            CreateRecurringTransactionRequest request = buildCreateRequest();
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+
+            assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Category type does not match transaction type");
+
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando conta nao existir")
+        void shouldThrowWhenAccountDoesNotExistOnCreate() {
+            User user = buildUser();
+
+            CreateRecurringTransactionRequest request = buildCreateRequest();
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Account not found");
+
+            verify(categoryRepository, never()).findByIdAndUserId(any(), any());
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria nao existir")
+        void shouldThrowWhenCategoryDoesNotExistOnCreate() {
+            User user = buildUser();
+            Account account = buildAccount();
+
+            CreateRecurringTransactionRequest request = buildCreateRequest();
+
+            mockAuthenticatedUser(user);
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Category not found");
+
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAll")
+    class FindAllTests {
+
+        @Test
+        @DisplayName("deve listar transacoes recorrentes do usuario autenticado")
+        void shouldFindAllRecurringTransactions() {
+            User user = buildUser();
+
+            RecurringTransaction first = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+
+            RecurringTransaction second = buildRecurringTransaction(
+                    101L,
+                    "Salario",
+                    TransactionType.INCOME,
+                    CategoryType.INCOME
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findAllByUserIdOrderByCreatedAtDesc(USER_ID))
+                    .thenReturn(List.of(first, second));
+
+            List<RecurringTransactionResponse> responses = recurringTransactionService.findAll(authentication);
+
+            assertThat(responses).hasSize(2);
+            assertThat(responses.get(0).id()).isEqualTo(RECURRING_TRANSACTION_ID);
+            assertThat(responses.get(0).description()).isEqualTo("Aluguel");
+            assertThat(responses.get(1).id()).isEqualTo(101L);
+            assertThat(responses.get(1).description()).isEqualTo("Salario");
+        }
+    }
+
+    @Nested
+    @DisplayName("findById")
+    class FindByIdTests {
+
+        @Test
+        @DisplayName("deve buscar transacao recorrente por id")
+        void shouldFindRecurringTransactionById() {
+            User user = buildUser();
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+
+            RecurringTransactionResponse response = recurringTransactionService.findById(
+                    RECURRING_TRANSACTION_ID,
+                    authentication
+            );
+
+            assertThat(response.id()).isEqualTo(RECURRING_TRANSACTION_ID);
+            assertThat(response.description()).isEqualTo("Aluguel");
+            assertThat(response.accountId()).isEqualTo(ACCOUNT_ID);
+            assertThat(response.categoryId()).isEqualTo(CATEGORY_ID);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando transacao recorrente nao existir")
+        void shouldThrowWhenRecurringTransactionDoesNotExist() {
+            User user = buildUser();
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recurringTransactionService.findById(RECURRING_TRANSACTION_ID, authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Recurring transaction not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("update")
+    class UpdateTests {
+
+        @Test
+        @DisplayName("deve atualizar transacao recorrente com sucesso")
+        void shouldUpdateRecurringTransactionSuccessfully() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setNextExecutionDate(LocalDate.of(2026, 4, 1));
+
+            UpdateRecurringTransactionRequest request = buildUpdateRequest(
+                    "  Internet  ",
+                    LocalDate.of(2026, 5, 1)
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.update(
+                    RECURRING_TRANSACTION_ID,
+                    request,
+                    authentication
+            );
+
+            assertThat(response.description()).isEqualTo("Internet");
+            assertThat(response.amount()).isEqualByComparingTo("150.00");
+            assertThat(response.active()).isTrue();
+            assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 5, 1));
+            assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 5, 1));
+
+            verify(recurringTransactionRepository).save(recurringTransaction);
+        }
+
+        @Test
+        @DisplayName("deve manter proxima execucao quando ela for posterior a nova data inicial")
+        void shouldKeepNextExecutionDateWhenItIsAfterStartDateOnUpdate() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setNextExecutionDate(LocalDate.of(2026, 6, 1));
+
+            UpdateRecurringTransactionRequest request = buildUpdateRequest(
+                    "Internet",
+                    LocalDate.of(2026, 5, 1)
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.update(
+                    RECURRING_TRANSACTION_ID,
+                    request,
+                    authentication
+            );
+
+            assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria nao combinar com tipo da transacao ao atualizar")
+        void shouldThrowWhenCategoryDoesNotMatchTransactionTypeOnUpdate() {
+            User user = buildUser();
+            Account account = buildAccount();
+            Category category = buildCategory(CategoryType.INCOME);
+
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+
+            UpdateRecurringTransactionRequest request = buildUpdateRequest(
+                    "Internet",
+                    LocalDate.of(2026, 5, 1)
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
+                    .thenReturn(Optional.of(account));
+            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
+                    .thenReturn(Optional.of(category));
+
+            assertThatThrownBy(() -> recurringTransactionService.update(RECURRING_TRANSACTION_ID, request, authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Category type does not match transaction type");
+
+            verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("delete")
+    class DeleteTests {
+
+        @Test
+        @DisplayName("deve deletar transacao recorrente")
+        void shouldDeleteRecurringTransaction() {
+            User user = buildUser();
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+
+            recurringTransactionService.delete(RECURRING_TRANSACTION_ID, authentication);
+
+            verify(recurringTransactionRepository).delete(recurringTransaction);
+        }
+    }
+
+    @Nested
+    @DisplayName("activate")
+    class ActivateTests {
+
+        @Test
+        @DisplayName("deve ativar transacao recorrente e definir proxima execucao quando estiver nula")
+        void shouldActivateAndSetNextExecutionDateWhenNull() {
+            User user = buildUser();
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setActive(false);
+            recurringTransaction.setNextExecutionDate(null);
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.activate(
+                    RECURRING_TRANSACTION_ID,
+                    authentication
+            );
+
+            assertThat(response.active()).isTrue();
+            assertThat(response.nextExecutionDate()).isEqualTo(recurringTransaction.getStartDate());
+        }
+
+        @Test
+        @DisplayName("deve ativar transacao recorrente mantendo proxima execucao existente")
+        void shouldActivateAndKeepExistingNextExecutionDate() {
+            User user = buildUser();
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setActive(false);
+            recurringTransaction.setNextExecutionDate(LocalDate.of(2026, 6, 1));
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.activate(
+                    RECURRING_TRANSACTION_ID,
+                    authentication
+            );
+
+            assertThat(response.active()).isTrue();
+            assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        }
+    }
+
+    @Nested
+    @DisplayName("deactivate")
+    class DeactivateTests {
+
+        @Test
+        @DisplayName("deve desativar transacao recorrente")
+        void shouldDeactivateRecurringTransaction() {
+            User user = buildUser();
+            RecurringTransaction recurringTransaction = buildRecurringTransaction(
+                    RECURRING_TRANSACTION_ID,
+                    "Aluguel",
+                    TransactionType.EXPENSE,
+                    CategoryType.EXPENSE
+            );
+            recurringTransaction.setActive(true);
+
+            mockAuthenticatedUser(user);
+            when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
+                    .thenReturn(Optional.of(recurringTransaction));
+            when(recurringTransactionRepository.save(recurringTransaction))
+                    .thenReturn(recurringTransaction);
+
+            RecurringTransactionResponse response = recurringTransactionService.deactivate(
+                    RECURRING_TRANSACTION_ID,
+                    authentication
+            );
+
+            assertThat(response.active()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("authentication")
+    class AuthenticationTests {
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication for nulo")
+        void shouldThrowWhenAuthenticationIsNull() {
+            assertThatThrownBy(() -> recurringTransactionService.findAll(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verifyNoInteractions(userRepository);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication nao possuir nome")
+        void shouldThrowWhenAuthenticationNameIsNull() {
+            when(authentication.getName()).thenReturn(null);
+
+            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication possuir nome em branco")
+        void shouldThrowWhenAuthenticationNameIsBlank() {
+            when(authentication.getName()).thenReturn("   ");
+
+            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando usuario autenticado nao existir")
+        void shouldThrowWhenAuthenticatedUserDoesNotExist() {
+            when(authentication.getName()).thenReturn("bryan@email.com");
+            when(userRepository.findByEmail("bryan@email.com"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Authenticated user not found");
+        }
+    }
+
+    private void mockAuthenticatedUser(User user) {
+        when(authentication.getName()).thenReturn(user.getEmail());
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+    }
+
+    private CreateRecurringTransactionRequest buildCreateRequest() {
+        return new CreateRecurringTransactionRequest(
+                "Aluguel",
+                new BigDecimal("1200.00"),
+                TransactionType.EXPENSE,
+                SourceType.WEB,
+                RecurrenceFrequency.MONTHLY,
+                LocalDate.of(2026, 4, 1),
+                LocalDate.of(2026, 12, 1),
+                ACCOUNT_ID,
+                CATEGORY_ID
+        );
+    }
+
+    private UpdateRecurringTransactionRequest buildUpdateRequest(
+            String description,
+            LocalDate startDate
+    ) {
+        return new UpdateRecurringTransactionRequest(
+                description,
+                new BigDecimal("150.00"),
+                TransactionType.EXPENSE,
+                SourceType.WEB,
+                RecurrenceFrequency.MONTHLY,
+                startDate,
+                LocalDate.of(2026, 12, 1),
+                ACCOUNT_ID,
+                CATEGORY_ID,
+                true
+        );
+    }
+
+    private RecurringTransaction buildRecurringTransaction(
+            Long id,
+            String description,
+            TransactionType transactionType,
+            CategoryType categoryType
+    ) {
+        RecurringTransaction recurringTransaction = new RecurringTransaction();
+        recurringTransaction.setId(id);
+        recurringTransaction.setDescription(description);
+        recurringTransaction.setAmount(new BigDecimal("1200.00"));
+        recurringTransaction.setType(transactionType);
+        recurringTransaction.setSourceType(SourceType.WEB);
+        recurringTransaction.setFrequency(RecurrenceFrequency.MONTHLY);
+        recurringTransaction.setStartDate(LocalDate.of(2026, 4, 1));
+        recurringTransaction.setEndDate(LocalDate.of(2026, 12, 1));
+        recurringTransaction.setNextExecutionDate(LocalDate.of(2026, 4, 1));
+        recurringTransaction.setActive(true);
+        recurringTransaction.setUser(buildUser());
+        recurringTransaction.setAccount(buildAccount());
+        recurringTransaction.setCategory(buildCategory(categoryType));
+        return recurringTransaction;
+    }
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(USER_ID);
+        user.setName("Bryan");
+        user.setEmail("bryan@email.com");
+        return user;
+    }
+
+    private Account buildAccount() {
+        Account account = new Account();
+        account.setId(ACCOUNT_ID);
+        account.setName("Banco Principal");
+        account.setType(AccountType.CHECKING_ACCOUNT);
+        account.setUser(buildUser());
+        return account;
+    }
+
+    private Category buildCategory(CategoryType type) {
+        Category category = new Category();
+        category.setId(CATEGORY_ID);
+        category.setName(type == CategoryType.EXPENSE ? "Moradia" : "Salário");
+        category.setType(type);
+        category.setUser(buildUser());
+        return category;
+    }
+}

--- a/src/test/java/com/financebot/user/service/UserServiceTest.java
+++ b/src/test/java/com/financebot/user/service/UserServiceTest.java
@@ -1,0 +1,398 @@
+package com.financebot.user.service;
+
+import com.financebot.user.domain.User;
+import com.financebot.user.dto.request.TelegramLinkConfirmRequest;
+import com.financebot.user.dto.request.UpdateMonthlyBaseIncomeRequest;
+import com.financebot.user.dto.response.CurrentUserResponse;
+import com.financebot.user.dto.response.TelegramLinkCodeResponse;
+import com.financebot.user.dto.response.TelegramLinkConfirmResponse;
+import com.financebot.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Nested
+    @DisplayName("getMe")
+    class GetMeTests {
+
+        @Test
+        @DisplayName("deve retornar dados do usuario autenticado")
+        void shouldReturnCurrentUserData() {
+            User user = buildUser();
+            user.setMonthlyBaseIncome(new BigDecimal("3500.00"));
+            user.setTelegramId(123456L);
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().plusMinutes(10));
+
+            mockAuthenticatedUser(user);
+
+            CurrentUserResponse response = userService.getMe(authentication);
+
+            assertThat(response.id()).isEqualTo(user.getId());
+            assertThat(response.name()).isEqualTo(user.getName());
+            assertThat(response.email()).isEqualTo(user.getEmail());
+            assertThat(response.monthlyBaseIncome()).isEqualByComparingTo("3500.00");
+            assertThat(response.telegramId()).isEqualTo(123456L);
+            assertThat(response.telegramLinked()).isTrue();
+            assertThat(response.telegramLinkCode()).isEqualTo("FIN-ABC123");
+            assertThat(response.telegramLinkCodeExpiresAt()).isEqualTo(user.getTelegramLinkCodeExpiresAt());
+        }
+
+        @Test
+        @DisplayName("deve retornar telegramLinked falso quando usuario nao tiver Telegram vinculado")
+        void shouldReturnTelegramLinkedFalseWhenUserHasNoTelegramId() {
+            User user = buildUser();
+            user.setTelegramId(null);
+
+            mockAuthenticatedUser(user);
+
+            CurrentUserResponse response = userService.getMe(authentication);
+
+            assertThat(response.telegramLinked()).isFalse();
+            assertThat(response.telegramId()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("updateMonthlyBaseIncome")
+    class UpdateMonthlyBaseIncomeTests {
+
+        @Test
+        @DisplayName("deve atualizar renda mensal base do usuario autenticado")
+        void shouldUpdateMonthlyBaseIncome() {
+            User user = buildUser();
+
+            UpdateMonthlyBaseIncomeRequest request = new UpdateMonthlyBaseIncomeRequest(
+                    new BigDecimal("4200.00")
+            );
+
+            mockAuthenticatedUser(user);
+
+            userService.updateMonthlyBaseIncome(request, authentication);
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+
+            User savedUser = captor.getValue();
+
+            assertThat(savedUser).isEqualTo(user);
+            assertThat(savedUser.getMonthlyBaseIncome()).isEqualByComparingTo("4200.00");
+        }
+    }
+
+    @Nested
+    @DisplayName("generateTelegramLinkCode")
+    class GenerateTelegramLinkCodeTests {
+
+        @Test
+        @DisplayName("deve gerar codigo de vinculo do Telegram")
+        void shouldGenerateTelegramLinkCode() {
+            User user = buildUser();
+
+            mockAuthenticatedUser(user);
+
+            TelegramLinkCodeResponse response = userService.generateTelegramLinkCode(authentication);
+
+            assertThat(response.telegramLinkCode()).startsWith("FIN-");
+            assertThat(response.telegramLinkCode()).hasSize(10);
+            assertThat(response.expiresAt()).isAfter(LocalDateTime.now());
+            assertThat(response.message()).isEqualTo("Send this code to the Telegram bot to link your account.");
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+
+            User savedUser = captor.getValue();
+
+            assertThat(savedUser.getTelegramLinkCode()).isEqualTo(response.telegramLinkCode());
+            assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isEqualTo(response.expiresAt());
+        }
+    }
+
+    @Nested
+    @DisplayName("confirmTelegramLink")
+    class ConfirmTelegramLinkTests {
+
+        @Test
+        @DisplayName("deve confirmar vinculo do Telegram com sucesso")
+        void shouldConfirmTelegramLinkSuccessfully() {
+            User user = buildUser();
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().plusMinutes(5));
+
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-ABC123",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-ABC123"))
+                    .thenReturn(Optional.of(user));
+
+            when(userRepository.existsByTelegramId(987654L))
+                    .thenReturn(false);
+
+            TelegramLinkConfirmResponse response = userService.confirmTelegramLink(request);
+
+            assertThat(response.success()).isTrue();
+            assertThat(response.message()).isEqualTo("Conta conectada com sucesso ao Telegram.");
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+
+            User savedUser = captor.getValue();
+
+            assertThat(savedUser.getTelegramId()).isEqualTo(987654L);
+            assertThat(savedUser.getTelegramLinkCode()).isNull();
+            assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isNull();
+        }
+
+        @Test
+        @DisplayName("deve retornar sucesso quando Telegram ja estava vinculado ao mesmo usuario")
+        void shouldReturnSuccessWhenTelegramWasAlreadyLinkedToSameUser() {
+            User user = buildUser();
+            user.setTelegramId(987654L);
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().plusMinutes(5));
+
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-ABC123",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-ABC123"))
+                    .thenReturn(Optional.of(user));
+
+            TelegramLinkConfirmResponse response = userService.confirmTelegramLink(request);
+
+            assertThat(response.success()).isTrue();
+            assertThat(response.message()).isEqualTo("Sua conta já estava conectada a este Telegram.");
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+
+            User savedUser = captor.getValue();
+
+            assertThat(savedUser.getTelegramId()).isEqualTo(987654L);
+            assertThat(savedUser.getTelegramLinkCode()).isNull();
+            assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isNull();
+
+            verify(userRepository, never()).existsByTelegramId(anyLong());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando codigo de vinculo nao existir")
+        void shouldThrowWhenLinkCodeDoesNotExist() {
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-INVALID",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-INVALID"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.confirmTelegramLink(request))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Código de vínculo inválido");
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando codigo de vinculo nao tiver data de expiracao")
+        void shouldThrowWhenLinkCodeExpirationIsNull() {
+            User user = buildUser();
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(null);
+
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-ABC123",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-ABC123"))
+                    .thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userService.confirmTelegramLink(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Código de vínculo expirado");
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando codigo de vinculo estiver expirado")
+        void shouldThrowWhenLinkCodeIsExpired() {
+            User user = buildUser();
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().minusMinutes(1));
+
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-ABC123",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-ABC123"))
+                    .thenReturn(Optional.of(user));
+
+            assertThatThrownBy(() -> userService.confirmTelegramLink(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Código de vínculo expirado");
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando Telegram ja estiver vinculado a outra conta")
+        void shouldThrowWhenTelegramIsAlreadyLinkedToAnotherAccount() {
+            User user = buildUser();
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().plusMinutes(5));
+
+            TelegramLinkConfirmRequest request = new TelegramLinkConfirmRequest(
+                    "FIN-ABC123",
+                    987654L,
+                    "bryan_telegram"
+            );
+
+            when(userRepository.findByTelegramLinkCode("FIN-ABC123"))
+                    .thenReturn(Optional.of(user));
+
+            when(userRepository.existsByTelegramId(987654L))
+                    .thenReturn(true);
+
+            assertThatThrownBy(() -> userService.confirmTelegramLink(request))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Este Telegram já está vinculado a outra conta");
+
+            verify(userRepository, never()).save(any(User.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("disconnectTelegram")
+    class DisconnectTelegramTests {
+
+        @Test
+        @DisplayName("deve desconectar Telegram do usuario autenticado")
+        void shouldDisconnectTelegram() {
+            User user = buildUser();
+            user.setTelegramId(987654L);
+            user.setTelegramLinkCode("FIN-ABC123");
+            user.setTelegramLinkCodeExpiresAt(LocalDateTime.now().plusMinutes(5));
+
+            mockAuthenticatedUser(user);
+
+            userService.disconnectTelegram(authentication);
+
+            ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+            verify(userRepository).save(captor.capture());
+
+            User savedUser = captor.getValue();
+
+            assertThat(savedUser.getTelegramId()).isNull();
+            assertThat(savedUser.getTelegramLinkCode()).isNull();
+            assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isNull();
+        }
+    }
+
+    @Nested
+    @DisplayName("authentication")
+    class AuthenticationTests {
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication for nulo")
+        void shouldThrowWhenAuthenticationIsNull() {
+            assertThatThrownBy(() -> userService.getMe(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verifyNoInteractions(userRepository);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication nao possuir nome")
+        void shouldThrowWhenAuthenticationNameIsNull() {
+            when(authentication.getName()).thenReturn(null);
+
+            assertThatThrownBy(() -> userService.getMe(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication possuir nome em branco")
+        void shouldThrowWhenAuthenticationNameIsBlank() {
+            when(authentication.getName()).thenReturn("   ");
+
+            assertThatThrownBy(() -> userService.getMe(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando usuario autenticado nao for encontrado")
+        void shouldThrowWhenAuthenticatedUserIsNotFound() {
+            when(authentication.getName()).thenReturn("bryan@email.com");
+            when(userRepository.findByEmail("bryan@email.com"))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userService.getMe(authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Authenticated user not found");
+        }
+    }
+
+    private void mockAuthenticatedUser(User user) {
+        when(authentication.getName()).thenReturn(user.getEmail());
+        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+    }
+
+    private User buildUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setName("Bryan");
+        user.setEmail("bryan@email.com");
+        user.setMonthlyBaseIncome(new BigDecimal("3000.00"));
+        return user;
+    }
+}


### PR DESCRIPTION
## Objetivo

Publicar na `main` as melhorias de cobertura geral de testes preparadas na branch `develop` para a versão `v1.1.3`.

## Alterações incluídas

- Adicionados testes unitários para `UserService`
- Adicionados testes unitários para `RecurringTransactionService`
- Cobertos fluxos de autenticação, vínculo e desvínculo do Telegram
- Cobertos fluxos de criação, consulta, atualização, ativação, desativação e exclusão de transações recorrentes
- Cobertas validações de conta, categoria, usuário autenticado e compatibilidade entre tipo de transação e tipo de categoria
- Cobertos cenários de `endDate` anterior a `startDate`
- Coberta atualização de transação recorrente com `active = false`
- Atualizado o `CHANGELOG.md`

## Resultado

- Overall Coverage aumentada de aproximadamente 40% para acima de 50%
- Quality Gate aprovado no SonarQube
- New Code Coverage mantido dentro do mínimo exigido
- Security, Reliability e Security Hotspots seguem zerados

## Testes

- `./mvnw clean verify`
- Análise local com SonarQube e JaCoCo

Closes #29