### PR TITLE
Add pull request template to repository

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Objetivo
+
+Descreva brevemente o objetivo deste PR.
+
+## Alterações realizadas
+
+- 
+- 
+- 
+
+## Tipo de mudança
+
+- [ ] Feature
+- [ ] Bugfix
+- [ ] Refatoração
+- [ ] Testes
+- [ ] Documentação
+- [ ] Configuração/infra
+
+## Checklist de qualidade
+
+- [ ] O PR tem escopo pequeno e claro
+- [ ] Executei `./mvnw clean verify`
+- [ ] Os testes automatizados passaram
+- [ ] Rodei análise local no SonarQube quando houve alteração relevante
+- [ ] O Quality Gate continua aprovado quando houve análise SonarQube
+- [ ] Não introduzi novas issues críticas de Security ou Reliability
+- [ ] Mantive ou aumentei a cobertura de New Code quando houve código novo
+- [ ] Atualizei o `CHANGELOG.md` quando necessário
+- [ ] Atualizei o `README.md` ou documentação quando necessário
+- [ ] Verifiquei que não foram adicionados tokens, senhas ou secrets
+
+## Evidências
+
+Adicione prints, logs ou observações relevantes.
+
+Exemplos:
+- Resultado do `./mvnw clean verify`
+- Print do SonarQube
+- Print da funcionalidade testada
+- Link da issue relacionada
+
+## Testes realizados
+
+- [ ] `./mvnw clean verify`
+- [ ] Testes unitários específicos
+- [ ] Teste manual
+- [ ] Análise SonarQube local
+- [ ] Não se aplica
+
+## Issue relacionada
+
+Closes #


### PR DESCRIPTION
## Objetivo

Adicionar um template de Pull Request com checklist de qualidade para padronizar o fluxo de revisão do projeto.

## Alterações realizadas

- Criado template em `.github/pull_request_template.md`
- Adicionado checklist para testes, SonarQube, Quality Gate, documentação e escopo do PR
- Adicionada seção para evidências e issue relacionada
- Adicionada verificação para evitar envio de tokens, senhas ou secrets

## Resultado esperado

- Facilitar a criação de PRs mais consistentes
- Reduzir esquecimentos antes de mergear alterações
- Padronizar validações como `./mvnw clean verify`, análise SonarQube e atualização de documentação

## Testes

- Alteração apenas documental/processual

Closes #38