### PR TITLE
refactor: organize DTO packages by domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- Reorganizados pacotes de DTOs por domínio, separando objetos de entrada e saída em `request` e `response`.
+
 ## v1.1.3
 ### Tests
 - Adicionados testes unitários para `UserService`, cobrindo autenticação, atualização de renda base e vínculo/desvínculo do Telegram.

--- a/src/main/java/com/financebot/account/controller/AccountController.java
+++ b/src/main/java/com/financebot/account/controller/AccountController.java
@@ -1,8 +1,8 @@
 package com.financebot.account.controller;
 
-import com.financebot.account.dto.AccountResponse;
-import com.financebot.account.dto.CreateAccountRequest;
-import com.financebot.account.dto.UpdateAccountRequest;
+import com.financebot.account.dto.response.AccountResponse;
+import com.financebot.account.dto.request.CreateAccountRequest;
+import com.financebot.account.dto.request.UpdateAccountRequest;
 import com.financebot.account.service.AccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/financebot/account/dto/request/CreateAccountRequest.java
+++ b/src/main/java/com/financebot/account/dto/request/CreateAccountRequest.java
@@ -1,4 +1,4 @@
-package com.financebot.account.dto;
+package com.financebot.account.dto.request;
 
 import com.financebot.account.domain.AccountType;
 import jakarta.validation.constraints.NotBlank;
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 
-public record UpdateAccountRequest(
+public record CreateAccountRequest(
 
         @NotBlank(message = "Name is required")
         @Size(max = 100, message = "Name must have at most 100 characters")

--- a/src/main/java/com/financebot/account/dto/request/UpdateAccountRequest.java
+++ b/src/main/java/com/financebot/account/dto/request/UpdateAccountRequest.java
@@ -1,4 +1,4 @@
-package com.financebot.account.dto;
+package com.financebot.account.dto.request;
 
 import com.financebot.account.domain.AccountType;
 import jakarta.validation.constraints.NotBlank;
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Size;
 
 import java.math.BigDecimal;
 
-public record CreateAccountRequest(
+public record UpdateAccountRequest(
 
         @NotBlank(message = "Name is required")
         @Size(max = 100, message = "Name must have at most 100 characters")

--- a/src/main/java/com/financebot/account/dto/response/AccountResponse.java
+++ b/src/main/java/com/financebot/account/dto/response/AccountResponse.java
@@ -1,4 +1,4 @@
-package com.financebot.account.dto;
+package com.financebot.account.dto.response;
 
 import com.financebot.account.domain.AccountType;
 

--- a/src/main/java/com/financebot/account/mapper/AccountMapper.java
+++ b/src/main/java/com/financebot/account/mapper/AccountMapper.java
@@ -1,9 +1,9 @@
 package com.financebot.account.mapper;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.dto.AccountResponse;
-import com.financebot.account.dto.CreateAccountRequest;
-import com.financebot.account.dto.UpdateAccountRequest;
+import com.financebot.account.dto.response.AccountResponse;
+import com.financebot.account.dto.request.CreateAccountRequest;
+import com.financebot.account.dto.request.UpdateAccountRequest;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;

--- a/src/main/java/com/financebot/account/service/AccountService.java
+++ b/src/main/java/com/financebot/account/service/AccountService.java
@@ -1,9 +1,9 @@
 package com.financebot.account.service;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.dto.AccountResponse;
-import com.financebot.account.dto.CreateAccountRequest;
-import com.financebot.account.dto.UpdateAccountRequest;
+import com.financebot.account.dto.response.AccountResponse;
+import com.financebot.account.dto.request.CreateAccountRequest;
+import com.financebot.account.dto.request.UpdateAccountRequest;
 import com.financebot.account.mapper.AccountMapper;
 import com.financebot.account.repository.AccountRepository;
 import com.financebot.transaction.domain.TransactionType;

--- a/src/main/java/com/financebot/ai/dto/AiParseRequest.java
+++ b/src/main/java/com/financebot/ai/dto/AiParseRequest.java
@@ -1,4 +1,0 @@
-package com.financebot.ai.dto;
-
-public class AiParseRequest {
-}

--- a/src/main/java/com/financebot/ai/dto/AiParseResponse.java
+++ b/src/main/java/com/financebot/ai/dto/AiParseResponse.java
@@ -1,4 +1,0 @@
-package com.financebot.ai.dto;
-
-public class AiParseResponse {
-}

--- a/src/main/java/com/financebot/ai/dto/ConfidenceResult.java
+++ b/src/main/java/com/financebot/ai/dto/ConfidenceResult.java
@@ -1,4 +1,0 @@
-package com.financebot.ai.dto;
-
-public class ConfidenceResult {
-}

--- a/src/main/java/com/financebot/ai/dto/request/AiParseRequest.java
+++ b/src/main/java/com/financebot/ai/dto/request/AiParseRequest.java
@@ -1,0 +1,4 @@
+package com.financebot.ai.dto.request;
+
+public class AiParseRequest {
+}

--- a/src/main/java/com/financebot/ai/dto/response/AiParseResponse.java
+++ b/src/main/java/com/financebot/ai/dto/response/AiParseResponse.java
@@ -1,0 +1,4 @@
+package com.financebot.ai.dto.response;
+
+public class AiParseResponse {
+}

--- a/src/main/java/com/financebot/ai/dto/response/ConfidenceResult.java
+++ b/src/main/java/com/financebot/ai/dto/response/ConfidenceResult.java
@@ -1,0 +1,4 @@
+package com.financebot.ai.dto.response;
+
+public class ConfidenceResult {
+}

--- a/src/main/java/com/financebot/auth/controller/AuthController.java
+++ b/src/main/java/com/financebot/auth/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.financebot.auth.controller;
 
-import com.financebot.auth.dto.AuthResponse;
-import com.financebot.auth.dto.LoginRequest;
-import com.financebot.auth.dto.RegisterRequest;
+import com.financebot.auth.dto.response.AuthResponse;
+import com.financebot.auth.dto.request.LoginRequest;
+import com.financebot.auth.dto.request.RegisterRequest;
 import com.financebot.auth.service.AuthService;
 import jakarta.validation.Valid;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/financebot/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/financebot/auth/dto/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.financebot.auth.dto;
+package com.financebot.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -8,11 +8,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class RegisterRequest {
-
-    @NotBlank(message = "O nome é obrigatório")
-    @Size(max = 120, message = "O nome deve ter no máximo 120 caracteres")
-    private String name;
+public class LoginRequest {
 
     @NotBlank(message = "O email é obrigatório")
     @Email(message = "Email inválido")
@@ -20,6 +16,6 @@ public class RegisterRequest {
     private String email;
 
     @NotBlank(message = "A senha é obrigatória")
-    @Size(min = 6, max = 255, message = "A senha deve ter entre 6 e 255 caracteres")
+    @Size(max = 255, message = "A senha deve ter no máximo 255 caracteres")
     private String password;
 }

--- a/src/main/java/com/financebot/auth/dto/request/RegisterRequest.java
+++ b/src/main/java/com/financebot/auth/dto/request/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.financebot.auth.dto;
+package com.financebot.auth.dto.request;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -8,7 +8,11 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public class LoginRequest {
+public class RegisterRequest {
+
+    @NotBlank(message = "O nome é obrigatório")
+    @Size(max = 120, message = "O nome deve ter no máximo 120 caracteres")
+    private String name;
 
     @NotBlank(message = "O email é obrigatório")
     @Email(message = "Email inválido")
@@ -16,6 +20,6 @@ public class LoginRequest {
     private String email;
 
     @NotBlank(message = "A senha é obrigatória")
-    @Size(max = 255, message = "A senha deve ter no máximo 255 caracteres")
+    @Size(min = 6, max = 255, message = "A senha deve ter entre 6 e 255 caracteres")
     private String password;
 }

--- a/src/main/java/com/financebot/auth/dto/response/AuthResponse.java
+++ b/src/main/java/com/financebot/auth/dto/response/AuthResponse.java
@@ -1,4 +1,4 @@
-package com.financebot.auth.dto;
+package com.financebot.auth.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/financebot/auth/service/AuthService.java
+++ b/src/main/java/com/financebot/auth/service/AuthService.java
@@ -1,8 +1,8 @@
 package com.financebot.auth.service;
 
-import com.financebot.auth.dto.AuthResponse;
-import com.financebot.auth.dto.LoginRequest;
-import com.financebot.auth.dto.RegisterRequest;
+import com.financebot.auth.dto.response.AuthResponse;
+import com.financebot.auth.dto.request.LoginRequest;
+import com.financebot.auth.dto.request.RegisterRequest;
 import com.financebot.category.service.CategoryService;
 import com.financebot.common.exception.UnauthorizedException;
 import com.financebot.common.exception.ValidationException;

--- a/src/main/java/com/financebot/category/controller/CategoryController.java
+++ b/src/main/java/com/financebot/category/controller/CategoryController.java
@@ -1,9 +1,9 @@
 package com.financebot.category.controller;
 
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.dto.CategoryResponse;
-import com.financebot.category.dto.CreateCategoryRequest;
-import com.financebot.category.dto.UpdateCategoryRequest;
+import com.financebot.category.dto.response.CategoryResponse;
+import com.financebot.category.dto.request.CreateCategoryRequest;
+import com.financebot.category.dto.request.UpdateCategoryRequest;
 import com.financebot.category.service.CategoryService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/financebot/category/dto/request/CreateCategoryRequest.java
+++ b/src/main/java/com/financebot/category/dto/request/CreateCategoryRequest.java
@@ -1,11 +1,11 @@
-package com.financebot.category.dto;
+package com.financebot.category.dto.request;
 
 import com.financebot.category.domain.CategoryType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record UpdateCategoryRequest(
+public record CreateCategoryRequest(
 
         @NotBlank(message = "Name is required")
         @Size(max = 100, message = "Name must have at most 100 characters")

--- a/src/main/java/com/financebot/category/dto/request/UpdateCategoryRequest.java
+++ b/src/main/java/com/financebot/category/dto/request/UpdateCategoryRequest.java
@@ -1,11 +1,11 @@
-package com.financebot.category.dto;
+package com.financebot.category.dto.request;
 
 import com.financebot.category.domain.CategoryType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record CreateCategoryRequest(
+public record UpdateCategoryRequest(
 
         @NotBlank(message = "Name is required")
         @Size(max = 100, message = "Name must have at most 100 characters")

--- a/src/main/java/com/financebot/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/financebot/category/dto/response/CategoryResponse.java
@@ -1,4 +1,4 @@
-package com.financebot.category.dto;
+package com.financebot.category.dto.response;
 
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;

--- a/src/main/java/com/financebot/category/mapper/CategoryMapper.java
+++ b/src/main/java/com/financebot/category/mapper/CategoryMapper.java
@@ -1,9 +1,9 @@
 package com.financebot.category.mapper;
 
 import com.financebot.category.domain.Category;
-import com.financebot.category.dto.CategoryResponse;
-import com.financebot.category.dto.CreateCategoryRequest;
-import com.financebot.category.dto.UpdateCategoryRequest;
+import com.financebot.category.dto.response.CategoryResponse;
+import com.financebot.category.dto.request.CreateCategoryRequest;
+import com.financebot.category.dto.request.UpdateCategoryRequest;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/com/financebot/category/service/CategoryService.java
+++ b/src/main/java/com/financebot/category/service/CategoryService.java
@@ -2,9 +2,9 @@ package com.financebot.category.service;
 
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.dto.CategoryResponse;
-import com.financebot.category.dto.CreateCategoryRequest;
-import com.financebot.category.dto.UpdateCategoryRequest;
+import com.financebot.category.dto.response.CategoryResponse;
+import com.financebot.category.dto.request.CreateCategoryRequest;
+import com.financebot.category.dto.request.UpdateCategoryRequest;
 import com.financebot.category.mapper.CategoryMapper;
 import com.financebot.category.repository.CategoryRepository;
 import com.financebot.user.domain.User;

--- a/src/test/java/com/financebot/account/service/AccountServiceTest.java
+++ b/src/test/java/com/financebot/account/service/AccountServiceTest.java
@@ -1,7 +1,7 @@
 package com.financebot.account.service;
 
 import com.financebot.account.domain.AccountType;
-import com.financebot.account.dto.UpdateAccountRequest;
+import com.financebot.account.dto.request.UpdateAccountRequest;
 import com.financebot.account.mapper.AccountMapper;
 import com.financebot.account.repository.AccountRepository;
 import com.financebot.transaction.repository.TransactionRepository;

--- a/src/test/java/com/financebot/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/financebot/category/service/CategoryServiceTest.java
@@ -1,7 +1,7 @@
 package com.financebot.category.service;
 
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.dto.UpdateCategoryRequest;
+import com.financebot.category.dto.request.UpdateCategoryRequest;
 import com.financebot.category.mapper.CategoryMapper;
 import com.financebot.category.repository.CategoryRepository;
 import com.financebot.user.domain.User;


### PR DESCRIPTION
## Objetivo

Padronizar a organização dos pacotes de DTOs por domínio, separando objetos de entrada e saída em `request` e `response`.

## Alterações realizadas

- Movidos DTOs de `account` para `dto/request` e `dto/response`
- Movidos DTOs de `category` para `dto/request` e `dto/response`
- Movidos DTOs de `auth` para `dto/request` e `dto/response`
- Movidos DTOs de `dashboard` para `dto/response`
- Movidos DTOs de `ai` para `dto/request` e `dto/response`
- Ajustados imports impactados pela reorganização

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [ ] Testes
- [ ] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [ ] O PR tem escopo pequeno e claro
- [ ] Executei `./mvnw clean verify`
- [ ] Os testes automatizados passaram
- [ ] Rodei análise local no SonarQube quando houve alteração relevante
- [ ] O Quality Gate continua aprovado quando houve análise SonarQube
- [ ] Não introduzi novas issues críticas de Security ou Reliability
- [ ] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [ ] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [ ] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- `./mvnw clean verify`
- Análise SonarQube local

## Issue relacionada

Closes #34