### PR TITLE
refactor: reduce service coupling and move installment rules to domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 # Changelog
 
-## [1.1.4]
+## [Unreleased]
 
-### Refactored
+## [1.1.4] - 2026-05-17
+
+### Changed
 - Centralizada a resolução do usuário autenticado com `AuthenticatedUserResolver`.
 - Centralizada a resolução de recursos pertencentes ao usuário com `UserResourceResolver`.
 - Centralizada a validação entre categoria e tipo de transação com `TransactionCategoryValidator`.
 - Extraída a lógica de parcelamento do `TransactionService` para o domínio de transações.
 - Adicionado modelo de domínio para plano de parcelamento com `InstallmentPlan`, `InstallmentPlanItem` e `InstallmentPlanFactory`.
 - Reduzida a responsabilidade do `TransactionService`, mantendo-o mais focado na orquestração do caso de uso.
+- Melhorada a separação entre regras de domínio e lógica de aplicação.
+- Reduzido o acoplamento entre services.
 
 ### Tests
 - Adicionados testes para `AuthenticatedUserResolver`.
@@ -16,10 +20,7 @@
 - Adicionados testes para `TransactionCategoryValidator`.
 - Adicionados testes para `InstallmentPlanFactory`.
 - Atualizados testes de `TransactionService`, `RecurringTransactionService` e `FinancialAnalysisService` após extrações de responsabilidades.
-
-### Quality
 - Mantida a suíte de testes automatizados passando após as refatorações.
-- Melhorada a separação entre regras de domínio e lógica de aplicação.
 
 ## v1.1.3
 ### Tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
 # Changelog
 
-## [Unreleased]
+## [1.1.4]
 
-### Added
-- Adicionado controle de conclusão do onboarding do usuário.
-- Adicionado endpoint `PATCH /users/me/onboarding-completed` para marcar o onboarding como concluído.
-
-### Changed
-- Padronizada a criação de respostas em mappers para os módulos `auth`, `user` e `recurring`.
-- Reorganizados pacotes de DTOs por domínio, separando objetos de entrada e saída em `request` e `response`.
+### Refactored
+- Centralizada a resolução do usuário autenticado com `AuthenticatedUserResolver`.
+- Centralizada a resolução de recursos pertencentes ao usuário com `UserResourceResolver`.
+- Centralizada a validação entre categoria e tipo de transação com `TransactionCategoryValidator`.
+- Extraída a lógica de parcelamento do `TransactionService` para o domínio de transações.
+- Adicionado modelo de domínio para plano de parcelamento com `InstallmentPlan`, `InstallmentPlanItem` e `InstallmentPlanFactory`.
+- Reduzida a responsabilidade do `TransactionService`, mantendo-o mais focado na orquestração do caso de uso.
 
 ### Tests
-- Adicionada cobertura de teste para conclusão do onboarding no `UserService`.
+- Adicionados testes para `AuthenticatedUserResolver`.
+- Adicionados testes para `UserResourceResolver`.
+- Adicionados testes para `TransactionCategoryValidator`.
+- Adicionados testes para `InstallmentPlanFactory`.
+- Atualizados testes de `TransactionService`, `RecurringTransactionService` e `FinancialAnalysisService` após extrações de responsabilidades.
+
+### Quality
+- Mantida a suíte de testes automatizados passando após as refatorações.
+- Melhorada a separação entre regras de domínio e lógica de aplicação.
 
 ## v1.1.3
 ### Tests

--- a/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
+++ b/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
@@ -1,10 +1,8 @@
 package com.financebot.analysis.service;
 
-import com.financebot.account.domain.Account;
 import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
 import com.financebot.category.domain.Category;
-import com.financebot.category.domain.CategoryType;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.TransactionType;
@@ -18,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -34,12 +33,12 @@ public class FinancialAnalysisService {
     private static final String TOTAL_INSTALLMENTS_INVALID_MESSAGE = "Total installments must be at least 2";
     private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
             "Installment transactions are allowed only for expenses";
-    private static final String CATEGORY_TYPE_MISMATCH_MESSAGE = "Category type does not match transaction type";
 
     private final TransactionRepository transactionRepository;
     private final RecurringTransactionRepository recurringTransactionRepository;
     private final UserResourceResolver userResourceResolver;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional(readOnly = true)
     public FinancialCommitmentResponse getFinancialCommitment(Authentication authentication) {
@@ -229,7 +228,7 @@ public class FinancialAnalysisService {
 
         Category category = userResourceResolver.resolveCategory(categoryId, userId);
 
-        validateCategoryMatchesTransactionType(category, transactionType);
+        transactionCategoryValidator.validate(category, transactionType);
     }
 
     private BigDecimal calculatePercentage(BigDecimal value, BigDecimal reference) {
@@ -568,18 +567,6 @@ public class FinancialAnalysisService {
                 riskLevel,
                 message
         );
-    }
-
-    private void validateCategoryMatchesTransactionType(Category category, TransactionType transactionType) {
-        boolean isIncomeMatch =
-                category.getType() == CategoryType.INCOME && transactionType == TransactionType.INCOME;
-
-        boolean isExpenseMatch =
-                category.getType() == CategoryType.EXPENSE && transactionType == TransactionType.EXPENSE;
-
-        if (!isIncomeMatch && !isExpenseMatch) {
-            throw new IllegalArgumentException(CATEGORY_TYPE_MISMATCH_MESSAGE);
-        }
     }
 
     private record InstallmentPurchaseAnalysisResult(

--- a/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
+++ b/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
@@ -14,12 +14,12 @@ import com.financebot.transaction.dto.request.CreateInstallmentTransactionReques
 import com.financebot.transaction.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.financebot.user.service.AuthenticatedUserResolver;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -39,18 +39,16 @@ public class FinancialAnalysisService {
     private static final String CATEGORY_TYPE_MISMATCH_MESSAGE = "Category type does not match transaction type";
     private static final String ACCOUNT_NOT_FOUND_MESSAGE = "Account not found";
     private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found";
-    private static final String AUTHENTICATED_USER_INVALID_MESSAGE = "Authenticated user is invalid";
-    private static final String AUTHENTICATED_USER_NOT_FOUND_MESSAGE = "Authenticated user not found";
 
     private final TransactionRepository transactionRepository;
     private final RecurringTransactionRepository recurringTransactionRepository;
-    private final UserRepository userRepository;
     private final AccountRepository accountRepository;
     private final CategoryRepository categoryRepository;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional(readOnly = true)
     public FinancialCommitmentResponse getFinancialCommitment(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         return buildCurrentAnalysis(user);
     }
 
@@ -113,7 +111,7 @@ public class FinancialAnalysisService {
             CreateTransactionRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         validateAccountAndCategoryOwnership(
                 request.accountId(),
@@ -158,7 +156,7 @@ public class FinancialAnalysisService {
             CreateInstallmentTransactionRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         validateInstallmentRequest(request);
 
@@ -597,15 +595,6 @@ public class FinancialAnalysisService {
     private Category getUserCategory(Long categoryId, Long userId) {
         return categoryRepository.findByIdAndUserId(categoryId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(CATEGORY_NOT_FOUND_MESSAGE));
-    }
-
-    private User getAuthenticatedUser(Authentication authentication) {
-        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
-            throw new IllegalArgumentException(AUTHENTICATED_USER_INVALID_MESSAGE);
-        }
-
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new EntityNotFoundException(AUTHENTICATED_USER_NOT_FOUND_MESSAGE));
     }
 
     private record InstallmentPurchaseAnalysisResult(

--- a/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
+++ b/src/main/java/com/financebot/analysis/service/FinancialAnalysisService.java
@@ -1,12 +1,10 @@
 package com.financebot.analysis.service;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.TransactionType;
@@ -14,7 +12,7 @@ import com.financebot.transaction.dto.request.CreateInstallmentTransactionReques
 import com.financebot.transaction.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
-import jakarta.persistence.EntityNotFoundException;
+import com.financebot.user.service.UserResourceResolver;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -37,13 +35,10 @@ public class FinancialAnalysisService {
     private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
             "Installment transactions are allowed only for expenses";
     private static final String CATEGORY_TYPE_MISMATCH_MESSAGE = "Category type does not match transaction type";
-    private static final String ACCOUNT_NOT_FOUND_MESSAGE = "Account not found";
-    private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found";
 
     private final TransactionRepository transactionRepository;
     private final RecurringTransactionRepository recurringTransactionRepository;
-    private final AccountRepository accountRepository;
-    private final CategoryRepository categoryRepository;
+    private final UserResourceResolver userResourceResolver;
     private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional(readOnly = true)
@@ -230,9 +225,9 @@ public class FinancialAnalysisService {
             Long userId,
             TransactionType transactionType
     ) {
-        getUserAccount(accountId, userId);
+        userResourceResolver.resolveAccount(accountId, userId);
 
-        Category category = getUserCategory(categoryId, userId);
+        Category category = userResourceResolver.resolveCategory(categoryId, userId);
 
         validateCategoryMatchesTransactionType(category, transactionType);
     }
@@ -585,16 +580,6 @@ public class FinancialAnalysisService {
         if (!isIncomeMatch && !isExpenseMatch) {
             throw new IllegalArgumentException(CATEGORY_TYPE_MISMATCH_MESSAGE);
         }
-    }
-
-    private Account getUserAccount(Long accountId, Long userId) {
-        return accountRepository.findByIdAndUserId(accountId, userId)
-                .orElseThrow(() -> new EntityNotFoundException(ACCOUNT_NOT_FOUND_MESSAGE));
-    }
-
-    private Category getUserCategory(Long categoryId, Long userId) {
-        return categoryRepository.findByIdAndUserId(categoryId, userId)
-                .orElseThrow(() -> new EntityNotFoundException(CATEGORY_NOT_FOUND_MESSAGE));
     }
 
     private record InstallmentPurchaseAnalysisResult(

--- a/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
+++ b/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
@@ -1,10 +1,8 @@
 package com.financebot.recurring.service;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.dto.request.CreateRecurringTransactionRequest;
 import com.financebot.recurring.dto.request.UpdateRecurringTransactionRequest;
@@ -13,6 +11,7 @@ import com.financebot.recurring.mapper.RecurringTransactionMapper;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.user.domain.User;
+import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -27,8 +26,7 @@ import java.util.List;
 public class RecurringTransactionService {
 
     private final RecurringTransactionRepository recurringTransactionRepository;
-    private final AccountRepository accountRepository;
-    private final CategoryRepository categoryRepository;
+    private final UserResourceResolver userResourceResolver;
     private final RecurringTransactionMapper recurringTransactionMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
 
@@ -38,8 +36,8 @@ public class RecurringTransactionService {
             Authentication authentication
     ) {
         User user = authenticatedUserResolver.resolve(authentication);
-        Account account = getUserAccount(request.accountId(), user.getId());
-        Category category = getUserCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
+        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         validateCategoryMatchesTransactionType(category, request.type());
 
@@ -90,8 +88,8 @@ public class RecurringTransactionService {
         User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
-        Account account = getUserAccount(request.accountId(), user.getId());
-        Category category = getUserCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
+        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         validateCategoryMatchesTransactionType(category, request.type());
 
@@ -154,16 +152,6 @@ public class RecurringTransactionService {
     private RecurringTransaction getUserRecurringTransaction(Long id, Long userId) {
         return recurringTransactionRepository.findByIdAndUserId(id, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Recurring transaction not found"));
-    }
-
-    private Account getUserAccount(Long accountId, Long userId) {
-        return accountRepository.findByIdAndUserId(accountId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("Account not found"));
-    }
-
-    private Category getUserCategory(Long categoryId, Long userId) {
-        return categoryRepository.findByIdAndUserId(categoryId, userId)
-                .orElseThrow(() -> new EntityNotFoundException("Category not found"));
     }
 
     private void validateCategoryMatchesTransactionType(Category category, TransactionType transactionType) {

--- a/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
+++ b/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
@@ -2,7 +2,6 @@ package com.financebot.recurring.service;
 
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
-import com.financebot.category.domain.CategoryType;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.dto.request.CreateRecurringTransactionRequest;
 import com.financebot.recurring.dto.request.UpdateRecurringTransactionRequest;
@@ -18,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 
 import java.util.List;
 
@@ -29,6 +29,7 @@ public class RecurringTransactionService {
     private final UserResourceResolver userResourceResolver;
     private final RecurringTransactionMapper recurringTransactionMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional
     public RecurringTransactionResponse create(
@@ -36,10 +37,11 @@ public class RecurringTransactionService {
             Authentication authentication
     ) {
         User user = authenticatedUserResolver.resolve(authentication);
+
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
-        validateCategoryMatchesTransactionType(category, request.type());
+        transactionCategoryValidator.validate(category, request.type());
 
         RecurringTransaction recurringTransaction = new RecurringTransaction();
         recurringTransaction.setDescription(request.description().trim());
@@ -91,7 +93,7 @@ public class RecurringTransactionService {
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
-        validateCategoryMatchesTransactionType(category, request.type());
+        transactionCategoryValidator.validate(category, request.type());
 
         recurringTransaction.setDescription(request.description().trim());
         recurringTransaction.setAmount(request.amount());
@@ -152,17 +154,5 @@ public class RecurringTransactionService {
     private RecurringTransaction getUserRecurringTransaction(Long id, Long userId) {
         return recurringTransactionRepository.findByIdAndUserId(id, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Recurring transaction not found"));
-    }
-
-    private void validateCategoryMatchesTransactionType(Category category, TransactionType transactionType) {
-        boolean isIncomeMatch =
-                category.getType() == CategoryType.INCOME && transactionType == TransactionType.INCOME;
-
-        boolean isExpenseMatch =
-                category.getType() == CategoryType.EXPENSE && transactionType == TransactionType.EXPENSE;
-
-        if (!isIncomeMatch && !isExpenseMatch) {
-            throw new IllegalArgumentException("Category type does not match transaction type");
-        }
     }
 }

--- a/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
+++ b/src/main/java/com/financebot/recurring/service/RecurringTransactionService.java
@@ -13,12 +13,12 @@ import com.financebot.recurring.mapper.RecurringTransactionMapper;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.financebot.user.service.AuthenticatedUserResolver;
 
 import java.util.List;
 
@@ -27,17 +27,17 @@ import java.util.List;
 public class RecurringTransactionService {
 
     private final RecurringTransactionRepository recurringTransactionRepository;
-    private final UserRepository userRepository;
     private final AccountRepository accountRepository;
     private final CategoryRepository categoryRepository;
     private final RecurringTransactionMapper recurringTransactionMapper;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional
     public RecurringTransactionResponse create(
             CreateRecurringTransactionRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         Account account = getUserAccount(request.accountId(), user.getId());
         Category category = getUserCategory(request.categoryId(), user.getId());
 
@@ -65,7 +65,7 @@ public class RecurringTransactionService {
 
     @Transactional(readOnly = true)
     public List<RecurringTransactionResponse> findAll(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         return recurringTransactionRepository.findAllByUserIdOrderByCreatedAtDesc(user.getId())
                 .stream()
@@ -75,7 +75,7 @@ public class RecurringTransactionService {
 
     @Transactional(readOnly = true)
     public RecurringTransactionResponse findById(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
         return recurringTransactionMapper.toResponse(recurringTransaction);
@@ -87,7 +87,7 @@ public class RecurringTransactionService {
             UpdateRecurringTransactionRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
         Account account = getUserAccount(request.accountId(), user.getId());
@@ -119,7 +119,7 @@ public class RecurringTransactionService {
 
     @Transactional
     public void delete(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
         recurringTransactionRepository.delete(recurringTransaction);
@@ -127,7 +127,7 @@ public class RecurringTransactionService {
 
     @Transactional
     public RecurringTransactionResponse activate(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
         recurringTransaction.setActive(true);
@@ -142,7 +142,7 @@ public class RecurringTransactionService {
 
     @Transactional
     public RecurringTransactionResponse deactivate(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         RecurringTransaction recurringTransaction = getUserRecurringTransaction(id, user.getId());
 
         recurringTransaction.setActive(false);
@@ -164,15 +164,6 @@ public class RecurringTransactionService {
     private Category getUserCategory(Long categoryId, Long userId) {
         return categoryRepository.findByIdAndUserId(categoryId, userId)
                 .orElseThrow(() -> new EntityNotFoundException("Category not found"));
-    }
-
-    private User getAuthenticatedUser(Authentication authentication) {
-        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
-            throw new IllegalArgumentException("Authenticated user is invalid");
-        }
-
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new EntityNotFoundException("Authenticated user not found"));
     }
 
     private void validateCategoryMatchesTransactionType(Category category, TransactionType transactionType) {

--- a/src/main/java/com/financebot/transaction/config/TransactionDomainConfig.java
+++ b/src/main/java/com/financebot/transaction/config/TransactionDomainConfig.java
@@ -1,0 +1,14 @@
+package com.financebot.transaction.config;
+
+import com.financebot.transaction.domain.installment.InstallmentPlanFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TransactionDomainConfig {
+
+    @Bean
+    public InstallmentPlanFactory installmentPlanFactory() {
+        return new InstallmentPlanFactory();
+    }
+}

--- a/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlan.java
+++ b/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlan.java
@@ -1,0 +1,10 @@
+package com.financebot.transaction.domain.installment;
+
+import java.util.List;
+
+public record InstallmentPlan(
+        String installmentGroupId,
+        Integer totalInstallments,
+        List<InstallmentPlanItem> items
+) {
+}

--- a/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlan.java
+++ b/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlan.java
@@ -7,4 +7,8 @@ public record InstallmentPlan(
         Integer totalInstallments,
         List<InstallmentPlanItem> items
 ) {
+
+    public InstallmentPlan {
+        items = List.copyOf(items);
+    }
 }

--- a/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanFactory.java
+++ b/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanFactory.java
@@ -1,7 +1,6 @@
 package com.financebot.transaction.domain.installment;
 
 import com.financebot.transaction.domain.TransactionType;
-import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -10,7 +9,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-@Component
 public class InstallmentPlanFactory {
 
     private static final int MONEY_SCALE = 2;
@@ -33,19 +31,23 @@ public class InstallmentPlanFactory {
         BigDecimal installmentAmount = totalAmount.divide(
                 BigDecimal.valueOf(totalInstallments),
                 MONEY_SCALE,
-                RoundingMode.DOWN
+                RoundingMode.HALF_UP
         );
 
-        BigDecimal distributedAmount = installmentAmount.multiply(BigDecimal.valueOf(totalInstallments));
-        BigDecimal adjustment = totalAmount.subtract(distributedAmount);
-
+        BigDecimal accumulated = BigDecimal.ZERO;
         List<InstallmentPlanItem> items = new ArrayList<>();
 
         for (int installmentNumber = 1; installmentNumber <= totalInstallments; installmentNumber++) {
-            BigDecimal amount = installmentAmount;
+            BigDecimal amount = calculateCurrentInstallmentAmount(
+                    installmentNumber,
+                    totalInstallments,
+                    installmentAmount,
+                    totalAmount,
+                    accumulated
+            );
 
-            if (installmentNumber == totalInstallments) {
-                amount = amount.add(adjustment);
+            if (installmentNumber < totalInstallments) {
+                accumulated = accumulated.add(amount);
             }
 
             items.add(new InstallmentPlanItem(
@@ -75,11 +77,25 @@ public class InstallmentPlanFactory {
         }
     }
 
+    private BigDecimal calculateCurrentInstallmentAmount(
+            int currentInstallment,
+            int totalInstallments,
+            BigDecimal installmentAmount,
+            BigDecimal totalAmount,
+            BigDecimal accumulated
+    ) {
+        if (currentInstallment < totalInstallments) {
+            return installmentAmount;
+        }
+
+        return totalAmount.subtract(accumulated);
+    }
+
     private String buildInstallmentDescription(
             String description,
             int installmentNumber,
             int totalInstallments
     ) {
-        return "%s - %d/%d".formatted(description, installmentNumber, totalInstallments);
+        return "%s - %d/%d".formatted(description.trim(), installmentNumber, totalInstallments);
     }
 }

--- a/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanFactory.java
+++ b/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanFactory.java
@@ -1,0 +1,85 @@
+package com.financebot.transaction.domain.installment;
+
+import com.financebot.transaction.domain.TransactionType;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class InstallmentPlanFactory {
+
+    private static final int MONEY_SCALE = 2;
+    private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
+            "Installment transactions are allowed only for expenses";
+    private static final String MINIMUM_INSTALLMENTS_MESSAGE =
+            "Total installments must be at least 2";
+
+    public InstallmentPlan create(
+            BigDecimal totalAmount,
+            String description,
+            LocalDate firstDate,
+            TransactionType type,
+            Integer totalInstallments
+    ) {
+        validate(type, totalInstallments);
+
+        String installmentGroupId = UUID.randomUUID().toString();
+
+        BigDecimal installmentAmount = totalAmount.divide(
+                BigDecimal.valueOf(totalInstallments),
+                MONEY_SCALE,
+                RoundingMode.DOWN
+        );
+
+        BigDecimal distributedAmount = installmentAmount.multiply(BigDecimal.valueOf(totalInstallments));
+        BigDecimal adjustment = totalAmount.subtract(distributedAmount);
+
+        List<InstallmentPlanItem> items = new ArrayList<>();
+
+        for (int installmentNumber = 1; installmentNumber <= totalInstallments; installmentNumber++) {
+            BigDecimal amount = installmentAmount;
+
+            if (installmentNumber == totalInstallments) {
+                amount = amount.add(adjustment);
+            }
+
+            items.add(new InstallmentPlanItem(
+                    amount,
+                    buildInstallmentDescription(description, installmentNumber, totalInstallments),
+                    firstDate.plusMonths(installmentNumber - 1L),
+                    installmentNumber,
+                    totalInstallments,
+                    installmentGroupId
+            ));
+        }
+
+        return new InstallmentPlan(
+                installmentGroupId,
+                totalInstallments,
+                items
+        );
+    }
+
+    private void validate(TransactionType type, Integer totalInstallments) {
+        if (type != TransactionType.EXPENSE) {
+            throw new IllegalArgumentException(INSTALLMENT_ONLY_EXPENSE_MESSAGE);
+        }
+
+        if (totalInstallments == null || totalInstallments < 2) {
+            throw new IllegalArgumentException(MINIMUM_INSTALLMENTS_MESSAGE);
+        }
+    }
+
+    private String buildInstallmentDescription(
+            String description,
+            int installmentNumber,
+            int totalInstallments
+    ) {
+        return "%s - %d/%d".formatted(description, installmentNumber, totalInstallments);
+    }
+}

--- a/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanItem.java
+++ b/src/main/java/com/financebot/transaction/domain/installment/InstallmentPlanItem.java
@@ -1,0 +1,14 @@
+package com.financebot.transaction.domain.installment;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record InstallmentPlanItem(
+        BigDecimal amount,
+        String description,
+        LocalDate date,
+        Integer installmentNumber,
+        Integer totalInstallments,
+        String installmentGroupId
+) {
+}

--- a/src/main/java/com/financebot/transaction/service/TransactionService.java
+++ b/src/main/java/com/financebot/transaction/service/TransactionService.java
@@ -1,10 +1,8 @@
 package com.financebot.transaction.service;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.dto.TransactionFilter;
@@ -17,6 +15,7 @@ import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.transaction.specification.TransactionSpecification;
 import com.financebot.user.domain.User;
+import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -38,8 +37,6 @@ import java.util.UUID;
 public class TransactionService {
 
     private static final String TRANSACTION_NOT_FOUND_MESSAGE = "Transaction not found";
-    private static final String ACCOUNT_NOT_FOUND_MESSAGE = "Account not found";
-    private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found";
     private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
             "Installment transactions are allowed only for expenses";
     private static final String TOTAL_INSTALLMENTS_MINIMUM_MESSAGE = "Total installments must be at least 2";
@@ -47,8 +44,7 @@ public class TransactionService {
     private static final String INVALID_PERIOD_MESSAGE = "Start date cannot be after end date";
 
     private final TransactionRepository transactionRepository;
-    private final AccountRepository accountRepository;
-    private final CategoryRepository categoryRepository;
+    private final UserResourceResolver userResourceResolver;
     private final TransactionMapper transactionMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
 
@@ -56,8 +52,8 @@ public class TransactionService {
     public TransactionResponse create(CreateTransactionRequest request, Authentication authentication) {
         User user = authenticatedUserResolver.resolve(authentication);
 
-        Account account = getUserAccount(request.accountId(), user.getId());
-        Category category = getUserCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
+        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         validateCategoryMatchesTransactionType(category, request.type());
 
@@ -98,8 +94,8 @@ public class TransactionService {
     ) {
         validateInstallmentRequest(request);
 
-        Account account = getUserAccount(request.accountId(), user.getId());
-        Category category = getUserCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
+        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         validateCategoryMatchesTransactionType(category, request.type());
 
@@ -188,8 +184,8 @@ public class TransactionService {
         User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
-        Account account = getUserAccount(request.accountId(), user.getId());
-        Category category = getUserCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
+        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         validateCategoryMatchesTransactionType(category, request.type());
 
@@ -282,16 +278,6 @@ public class TransactionService {
     private Transaction getUserTransaction(Long transactionId, Long userId) {
         return transactionRepository.findByIdAndUserId(transactionId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(TRANSACTION_NOT_FOUND_MESSAGE));
-    }
-
-    private Account getUserAccount(Long accountId, Long userId) {
-        return accountRepository.findByIdAndUserId(accountId, userId)
-                .orElseThrow(() -> new EntityNotFoundException(ACCOUNT_NOT_FOUND_MESSAGE));
-    }
-
-    private Category getUserCategory(Long categoryId, Long userId) {
-        return categoryRepository.findByIdAndUserId(categoryId, userId)
-                .orElseThrow(() -> new EntityNotFoundException(CATEGORY_NOT_FOUND_MESSAGE));
     }
 
     private record InstallmentTransactionContext(

--- a/src/main/java/com/financebot/transaction/service/TransactionService.java
+++ b/src/main/java/com/financebot/transaction/service/TransactionService.java
@@ -17,7 +17,6 @@ import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.transaction.specification.TransactionSpecification;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +24,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.financebot.user.service.AuthenticatedUserResolver;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -40,8 +40,6 @@ public class TransactionService {
     private static final String TRANSACTION_NOT_FOUND_MESSAGE = "Transaction not found";
     private static final String ACCOUNT_NOT_FOUND_MESSAGE = "Account not found";
     private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found";
-    private static final String AUTHENTICATED_USER_NOT_FOUND_MESSAGE = "Authenticated user not found";
-    private static final String AUTHENTICATED_USER_INVALID_MESSAGE = "Authenticated user is invalid";
     private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
             "Installment transactions are allowed only for expenses";
     private static final String TOTAL_INSTALLMENTS_MINIMUM_MESSAGE = "Total installments must be at least 2";
@@ -49,14 +47,14 @@ public class TransactionService {
     private static final String INVALID_PERIOD_MESSAGE = "Start date cannot be after end date";
 
     private final TransactionRepository transactionRepository;
-    private final UserRepository userRepository;
     private final AccountRepository accountRepository;
     private final CategoryRepository categoryRepository;
     private final TransactionMapper transactionMapper;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional
     public TransactionResponse create(CreateTransactionRequest request, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         Account account = getUserAccount(request.accountId(), user.getId());
         Category category = getUserCategory(request.categoryId(), user.getId());
@@ -81,7 +79,7 @@ public class TransactionService {
             CreateInstallmentTransactionRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         return createInstallmentInternal(request, user);
     }
@@ -166,7 +164,7 @@ public class TransactionService {
             Authentication authentication,
             Pageable pageable
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         validatePeriod(filter.startDate(), filter.endDate());
 
@@ -179,7 +177,7 @@ public class TransactionService {
 
     @Transactional(readOnly = true)
     public TransactionResponse findById(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
         return transactionMapper.toResponse(transaction);
@@ -187,7 +185,7 @@ public class TransactionService {
 
     @Transactional
     public TransactionResponse update(Long id, UpdateTransactionRequest request, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
         Account account = getUserAccount(request.accountId(), user.getId());
@@ -205,7 +203,7 @@ public class TransactionService {
 
     @Transactional
     public void delete(Long id, Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
         transactionRepository.delete(transaction);
@@ -294,15 +292,6 @@ public class TransactionService {
     private Category getUserCategory(Long categoryId, Long userId) {
         return categoryRepository.findByIdAndUserId(categoryId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(CATEGORY_NOT_FOUND_MESSAGE));
-    }
-
-    private User getAuthenticatedUser(Authentication authentication) {
-        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
-            throw new IllegalArgumentException(AUTHENTICATED_USER_INVALID_MESSAGE);
-        }
-
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new EntityNotFoundException(AUTHENTICATED_USER_NOT_FOUND_MESSAGE));
     }
 
     private record InstallmentTransactionContext(

--- a/src/main/java/com/financebot/transaction/service/TransactionService.java
+++ b/src/main/java/com/financebot/transaction/service/TransactionService.java
@@ -2,7 +2,6 @@ package com.financebot.transaction.service;
 
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
-import com.financebot.category.domain.CategoryType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.dto.TransactionFilter;
@@ -24,6 +23,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -40,13 +40,13 @@ public class TransactionService {
     private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
             "Installment transactions are allowed only for expenses";
     private static final String TOTAL_INSTALLMENTS_MINIMUM_MESSAGE = "Total installments must be at least 2";
-    private static final String CATEGORY_TYPE_MISMATCH_MESSAGE = "Category type does not match transaction type";
     private static final String INVALID_PERIOD_MESSAGE = "Start date cannot be after end date";
 
     private final TransactionRepository transactionRepository;
     private final UserResourceResolver userResourceResolver;
     private final TransactionMapper transactionMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional
     public TransactionResponse create(CreateTransactionRequest request, Authentication authentication) {
@@ -55,7 +55,7 @@ public class TransactionService {
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
-        validateCategoryMatchesTransactionType(category, request.type());
+        transactionCategoryValidator.validate(category, request.type());
 
         Transaction transaction = transactionMapper.toEntity(request);
         transaction.setUser(user);
@@ -97,7 +97,7 @@ public class TransactionService {
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
-        validateCategoryMatchesTransactionType(category, request.type());
+        transactionCategoryValidator.validate(category, request.type());
 
         String installmentGroupId = UUID.randomUUID().toString();
         int totalInstallments = request.totalInstallments();
@@ -187,7 +187,7 @@ public class TransactionService {
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
-        validateCategoryMatchesTransactionType(category, request.type());
+        transactionCategoryValidator.validate(category, request.type());
 
         transactionMapper.updateEntity(request, transaction);
         transaction.setAccount(account);
@@ -255,18 +255,6 @@ public class TransactionService {
         transaction.setInstallmentGroupId(context.installmentGroupId());
 
         return transaction;
-    }
-
-    private void validateCategoryMatchesTransactionType(Category category, TransactionType transactionType) {
-        boolean isIncomeMatch =
-                category.getType() == CategoryType.INCOME && transactionType == TransactionType.INCOME;
-
-        boolean isExpenseMatch =
-                category.getType() == CategoryType.EXPENSE && transactionType == TransactionType.EXPENSE;
-
-        if (!isIncomeMatch && !isExpenseMatch) {
-            throw new IllegalArgumentException(CATEGORY_TYPE_MISMATCH_MESSAGE);
-        }
     }
 
     private void validatePeriod(LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/financebot/transaction/service/TransactionService.java
+++ b/src/main/java/com/financebot/transaction/service/TransactionService.java
@@ -3,7 +3,9 @@ package com.financebot.transaction.service;
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
 import com.financebot.transaction.domain.Transaction;
-import com.financebot.transaction.domain.TransactionType;
+import com.financebot.transaction.domain.installment.InstallmentPlan;
+import com.financebot.transaction.domain.installment.InstallmentPlanFactory;
+import com.financebot.transaction.domain.installment.InstallmentPlanItem;
 import com.financebot.transaction.dto.TransactionFilter;
 import com.financebot.transaction.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.dto.request.CreateTransactionRequest;
@@ -13,7 +15,9 @@ import com.financebot.transaction.dto.response.TransactionResponse;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.transaction.specification.TransactionSpecification;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
+import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -22,24 +26,15 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import com.financebot.user.service.AuthenticatedUserResolver;
-import com.financebot.transaction.validation.TransactionCategoryValidator;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class TransactionService {
 
     private static final String TRANSACTION_NOT_FOUND_MESSAGE = "Transaction not found";
-    private static final String INSTALLMENT_ONLY_EXPENSE_MESSAGE =
-            "Installment transactions are allowed only for expenses";
-    private static final String TOTAL_INSTALLMENTS_MINIMUM_MESSAGE = "Total installments must be at least 2";
     private static final String INVALID_PERIOD_MESSAGE = "Start date cannot be after end date";
 
     private final TransactionRepository transactionRepository;
@@ -47,6 +42,7 @@ public class TransactionService {
     private final TransactionMapper transactionMapper;
     private final AuthenticatedUserResolver authenticatedUserResolver;
     private final TransactionCategoryValidator transactionCategoryValidator;
+    private final InstallmentPlanFactory installmentPlanFactory;
 
     @Transactional
     public TransactionResponse create(CreateTransactionRequest request, Authentication authentication) {
@@ -67,6 +63,7 @@ public class TransactionService {
         transaction.setInstallmentGroupId(null);
 
         Transaction savedTransaction = transactionRepository.save(transaction);
+
         return transactionMapper.toResponse(savedTransaction);
     }
 
@@ -92,54 +89,28 @@ public class TransactionService {
             CreateInstallmentTransactionRequest request,
             User user
     ) {
-        validateInstallmentRequest(request);
+        InstallmentPlan plan = installmentPlanFactory.create(
+                request.totalAmount(),
+                request.description(),
+                request.firstInstallmentDate(),
+                request.type(),
+                request.totalInstallments()
+        );
 
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
 
         transactionCategoryValidator.validate(category, request.type());
 
-        String installmentGroupId = UUID.randomUUID().toString();
-        int totalInstallments = request.totalInstallments();
-        BigDecimal totalAmount = request.totalAmount();
-
-        BigDecimal installmentAmount = totalAmount.divide(
-                BigDecimal.valueOf(totalInstallments),
-                2,
-                RoundingMode.HALF_UP
-        );
-
-        BigDecimal accumulated = BigDecimal.ZERO;
-        List<Transaction> transactions = new ArrayList<>();
-
-        InstallmentTransactionContext context = new InstallmentTransactionContext(
-                request,
-                user,
-                account,
-                category,
-                installmentGroupId,
-                totalInstallments
-        );
-
-        for (int i = 1; i <= totalInstallments; i++) {
-            BigDecimal currentAmount = calculateCurrentInstallmentAmount(
-                    i,
-                    totalInstallments,
-                    installmentAmount,
-                    totalAmount,
-                    accumulated
-            );
-
-            if (i < totalInstallments) {
-                accumulated = accumulated.add(currentAmount);
-            }
-
-            transactions.add(buildInstallmentTransaction(
-                    context,
-                    i,
-                    currentAmount
-            ));
-        }
+        List<Transaction> transactions = plan.items().stream()
+                .map(item -> buildInstallmentTransaction(
+                        item,
+                        request,
+                        user,
+                        account,
+                        category
+                ))
+                .toList();
 
         List<Transaction> savedTransactions = transactionRepository.saveAll(transactions);
 
@@ -148,8 +119,8 @@ public class TransactionService {
                 .toList();
 
         return new InstallmentTransactionResponse(
-                installmentGroupId,
-                totalInstallments,
+                plan.installmentGroupId(),
+                plan.totalInstallments(),
                 responses
         );
     }
@@ -176,6 +147,7 @@ public class TransactionService {
         User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
+
         return transactionMapper.toResponse(transaction);
     }
 
@@ -194,6 +166,7 @@ public class TransactionService {
         transaction.setCategory(category);
 
         Transaction updatedTransaction = transactionRepository.save(transaction);
+
         return transactionMapper.toResponse(updatedTransaction);
     }
 
@@ -202,57 +175,31 @@ public class TransactionService {
         User user = authenticatedUserResolver.resolve(authentication);
 
         Transaction transaction = getUserTransaction(id, user.getId());
+
         transactionRepository.delete(transaction);
     }
 
-    private void validateInstallmentRequest(CreateInstallmentTransactionRequest request) {
-        if (request.type() != TransactionType.EXPENSE) {
-            throw new IllegalArgumentException(INSTALLMENT_ONLY_EXPENSE_MESSAGE);
-        }
-
-        if (request.totalInstallments() == null || request.totalInstallments() < 2) {
-            throw new IllegalArgumentException(TOTAL_INSTALLMENTS_MINIMUM_MESSAGE);
-        }
-    }
-
-    private BigDecimal calculateCurrentInstallmentAmount(
-            int currentInstallment,
-            int totalInstallments,
-            BigDecimal installmentAmount,
-            BigDecimal totalAmount,
-            BigDecimal accumulated
-    ) {
-        if (currentInstallment < totalInstallments) {
-            return installmentAmount;
-        }
-
-        return totalAmount.subtract(accumulated);
-    }
-
     private Transaction buildInstallmentTransaction(
-            InstallmentTransactionContext context,
-            int installmentNumber,
-            BigDecimal currentAmount
+            InstallmentPlanItem item,
+            CreateInstallmentTransactionRequest request,
+            User user,
+            Account account,
+            Category category
     ) {
         Transaction transaction = new Transaction();
-        transaction.setAmount(currentAmount);
-        transaction.setDescription(
-                context.request().description().trim()
-                        + " - "
-                        + installmentNumber
-                        + "/"
-                        + context.totalInstallments()
-        );
-        transaction.setDate(context.request().firstInstallmentDate().plusMonths((long) installmentNumber - 1));
-        transaction.setType(context.request().type());
-        transaction.setSourceType(context.request().sourceType());
-        transaction.setUser(context.user());
-        transaction.setAccount(context.account());
-        transaction.setCategory(context.category());
+
+        transaction.setAmount(item.amount());
+        transaction.setDescription(item.description());
+        transaction.setDate(item.date());
+        transaction.setType(request.type());
+        transaction.setSourceType(request.sourceType());
+        transaction.setUser(user);
+        transaction.setAccount(account);
+        transaction.setCategory(category);
         transaction.setInstallment(true);
-        transaction.setInstallmentNumber(installmentNumber);
-        transaction.setTotalInstallments(context.totalInstallments());
-        transaction.setInstallmentGroupId(context.installmentGroupId());
+        transaction.setInstallmentNumber(item.installmentNumber());
+        transaction.setTotalInstallments(item.totalInstallments());
+        transaction.setInstallmentGroupId(item.installmentGroupId());
 
         return transaction;
     }
@@ -266,15 +213,5 @@ public class TransactionService {
     private Transaction getUserTransaction(Long transactionId, Long userId) {
         return transactionRepository.findByIdAndUserId(transactionId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(TRANSACTION_NOT_FOUND_MESSAGE));
-    }
-
-    private record InstallmentTransactionContext(
-            CreateInstallmentTransactionRequest request,
-            User user,
-            Account account,
-            Category category,
-            String installmentGroupId,
-            int totalInstallments
-    ) {
     }
 }

--- a/src/main/java/com/financebot/transaction/validation/TransactionCategoryValidator.java
+++ b/src/main/java/com/financebot/transaction/validation/TransactionCategoryValidator.java
@@ -1,0 +1,25 @@
+package com.financebot.transaction.validation;
+
+import com.financebot.category.domain.Category;
+import com.financebot.category.domain.CategoryType;
+import com.financebot.transaction.domain.TransactionType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TransactionCategoryValidator {
+
+    private static final String CATEGORY_TYPE_MISMATCH_MESSAGE =
+            "Category type does not match transaction type";
+
+    public void validate(Category category, TransactionType transactionType) {
+        boolean isIncomeMatch =
+                category.getType() == CategoryType.INCOME && transactionType == TransactionType.INCOME;
+
+        boolean isExpenseMatch =
+                category.getType() == CategoryType.EXPENSE && transactionType == TransactionType.EXPENSE;
+
+        if (!isIncomeMatch && !isExpenseMatch) {
+            throw new IllegalArgumentException(CATEGORY_TYPE_MISMATCH_MESSAGE);
+        }
+    }
+}

--- a/src/main/java/com/financebot/user/service/AuthenticatedUserResolver.java
+++ b/src/main/java/com/financebot/user/service/AuthenticatedUserResolver.java
@@ -1,0 +1,27 @@
+package com.financebot.user.service;
+
+import com.financebot.user.domain.User;
+import com.financebot.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuthenticatedUserResolver {
+
+    private static final String AUTHENTICATED_USER_INVALID_MESSAGE = "Authenticated user is invalid";
+    private static final String AUTHENTICATED_USER_NOT_FOUND_MESSAGE = "Authenticated user not found";
+
+    private final UserRepository userRepository;
+
+    public User resolve(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
+            throw new IllegalArgumentException(AUTHENTICATED_USER_INVALID_MESSAGE);
+        }
+
+        return userRepository.findByEmail(authentication.getName())
+                .orElseThrow(() -> new EntityNotFoundException(AUTHENTICATED_USER_NOT_FOUND_MESSAGE));
+    }
+}

--- a/src/main/java/com/financebot/user/service/UserResourceResolver.java
+++ b/src/main/java/com/financebot/user/service/UserResourceResolver.java
@@ -1,0 +1,30 @@
+package com.financebot.user.service;
+
+import com.financebot.account.domain.Account;
+import com.financebot.account.repository.AccountRepository;
+import com.financebot.category.domain.Category;
+import com.financebot.category.repository.CategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserResourceResolver {
+
+    private static final String ACCOUNT_NOT_FOUND_MESSAGE = "Account not found";
+    private static final String CATEGORY_NOT_FOUND_MESSAGE = "Category not found";
+
+    private final AccountRepository accountRepository;
+    private final CategoryRepository categoryRepository;
+
+    public Account resolveAccount(Long accountId, Long userId) {
+        return accountRepository.findByIdAndUserId(accountId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(ACCOUNT_NOT_FOUND_MESSAGE));
+    }
+
+    public Category resolveCategory(Long categoryId, Long userId) {
+        return categoryRepository.findByIdAndUserId(categoryId, userId)
+                .orElseThrow(() -> new EntityNotFoundException(CATEGORY_NOT_FOUND_MESSAGE));
+    }
+}

--- a/src/main/java/com/financebot/user/service/UserService.java
+++ b/src/main/java/com/financebot/user/service/UserService.java
@@ -29,10 +29,11 @@ public class UserService {
     private final UserRepository userRepository;
     private final UserMapper userMapper;
     private final SecureRandom secureRandom = new SecureRandom();
+    private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional(readOnly = true)
     public CurrentUserResponse getMe(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         return userMapper.toCurrentUserResponse(user);
     }
 
@@ -41,14 +42,14 @@ public class UserService {
             UpdateMonthlyBaseIncomeRequest request,
             Authentication authentication
     ) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
         user.setMonthlyBaseIncome(request.monthlyBaseIncome());
         userRepository.save(user);
     }
 
     @Transactional
     public TelegramLinkCodeResponse generateTelegramLinkCode(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         String code = TELEGRAM_CODE_PREFIX + generateRandomCode();
         LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(TELEGRAM_CODE_EXPIRATION_MINUTES);
@@ -95,7 +96,7 @@ public class UserService {
 
     @Transactional
     public void disconnectTelegram(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         user.setTelegramId(null);
         user.setTelegramLinkCode(null);
@@ -104,18 +105,9 @@ public class UserService {
         userRepository.save(user);
     }
 
-    private User getAuthenticatedUser(Authentication authentication) {
-        if (authentication == null || authentication.getName() == null || authentication.getName().isBlank()) {
-            throw new IllegalArgumentException("Authenticated user is invalid");
-        }
-
-        return userRepository.findByEmail(authentication.getName())
-                .orElseThrow(() -> new EntityNotFoundException("Authenticated user not found"));
-    }
-
     @Transactional
     public void completeOnboarding(Authentication authentication) {
-        User user = getAuthenticatedUser(authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
 
         user.setOnboardingCompleted(true);
 

--- a/src/test/java/com/financebot/analysis/service/FinancialAnalysisServiceTest.java
+++ b/src/test/java/com/financebot/analysis/service/FinancialAnalysisServiceTest.java
@@ -4,6 +4,7 @@ import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.repository.TransactionRepository;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
@@ -38,6 +39,9 @@ class FinancialAnalysisServiceTest {
 
     @Mock
     private UserResourceResolver userResourceResolver;
+
+    @Mock
+    private TransactionCategoryValidator transactionCategoryValidator;
 
     @InjectMocks
     private FinancialAnalysisService financialAnalysisService;

--- a/src/test/java/com/financebot/analysis/service/FinancialAnalysisServiceTest.java
+++ b/src/test/java/com/financebot/analysis/service/FinancialAnalysisServiceTest.java
@@ -1,13 +1,12 @@
 package com.financebot.analysis.service;
 
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
+import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.user.service.UserResourceResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,13 +34,10 @@ class FinancialAnalysisServiceTest {
     private RecurringTransactionRepository recurringTransactionRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Mock
-    private AccountRepository accountRepository;
-
-    @Mock
-    private CategoryRepository categoryRepository;
+    private UserResourceResolver userResourceResolver;
 
     @InjectMocks
     private FinancialAnalysisService financialAnalysisService;
@@ -120,12 +116,14 @@ class FinancialAnalysisServiceTest {
     @DisplayName("deve classificar como desfavoravel quando nao houver renda de referencia")
     void shouldClassifyAsDesfavoravelWhenIncomeReferenceIsZero() {
         user.setMonthlyBaseIncome(BigDecimal.ZERO);
+
         mockCurrentAnalysisData(
                 BigDecimal.ZERO,
                 new BigDecimal("500"),
                 1L,
                 List.of()
         );
+
         when(transactionRepository.sumIncomeBetweenDatesByUser(eq(1L), any(), any()))
                 .thenReturn(BigDecimal.ZERO);
 
@@ -185,7 +183,8 @@ class FinancialAnalysisServiceTest {
                 user,
                 BigDecimal.ZERO,
                 12
-        )).isInstanceOf(IllegalArgumentException.class)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Total amount must be greater than zero");
     }
 
@@ -198,7 +197,8 @@ class FinancialAnalysisServiceTest {
                 user,
                 totalAmount,
                 1
-        )).isInstanceOf(IllegalArgumentException.class)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Total installments must be at least 2");
     }
 
@@ -210,10 +210,13 @@ class FinancialAnalysisServiceTest {
     ) {
         when(transactionRepository.sumFutureInstallmentsByUser(eq(1L), any()))
                 .thenReturn(futureInstallments);
+
         when(transactionRepository.sumProjectedExpensesBetweenDatesByUser(eq(1L), any(), any()))
                 .thenReturn(projectedExpensesNextMonth);
+
         when(transactionRepository.countDistinctActiveInstallmentGroupsByUser(eq(1L), any()))
                 .thenReturn(activeInstallmentCount);
+
         when(recurringTransactionRepository.findAllByUserIdAndActiveTrue(1L))
                 .thenReturn(recurringTransactions);
     }

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -13,6 +13,7 @@ import com.financebot.recurring.mapper.RecurringTransactionMapper;
 import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.TransactionType;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
@@ -35,8 +36,10 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -58,6 +61,9 @@ class RecurringTransactionServiceTest {
 
     @Mock
     private UserResourceResolver userResourceResolver;
+
+    @Mock
+    private TransactionCategoryValidator transactionCategoryValidator;
 
     @Mock
     private Authentication authentication;
@@ -120,6 +126,8 @@ class RecurringTransactionServiceTest {
             assertThat(saved.getUser()).isEqualTo(user);
             assertThat(saved.getAccount()).isEqualTo(account);
             assertThat(saved.getCategory()).isEqualTo(category);
+
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
 
         @Test
@@ -150,6 +158,8 @@ class RecurringTransactionServiceTest {
             RecurringTransactionResponse response = recurringTransactionService.create(request, authentication);
 
             assertThat(response.description()).isEqualTo("Academia");
+
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
 
         @Test
@@ -164,6 +174,10 @@ class RecurringTransactionServiceTest {
             mockAuthenticatedUser(user);
             when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
             when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
+
+            doThrow(new IllegalArgumentException("Category type does not match transaction type"))
+                    .when(transactionCategoryValidator)
+                    .validate(category, TransactionType.EXPENSE);
 
             assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -188,6 +202,7 @@ class RecurringTransactionServiceTest {
                     .hasMessage("Account not found");
 
             verify(userResourceResolver, never()).resolveCategory(any(), any());
+            verifyNoInteractions(transactionCategoryValidator);
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
 
@@ -208,6 +223,7 @@ class RecurringTransactionServiceTest {
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Category not found");
 
+            verifyNoInteractions(transactionCategoryValidator);
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
 
@@ -238,6 +254,7 @@ class RecurringTransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("End date cannot be before start date");
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
     }
@@ -368,6 +385,7 @@ class RecurringTransactionServiceTest {
             assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 5, 1));
             assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 5, 1));
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
             verify(recurringTransactionRepository).save(recurringTransaction);
         }
 
@@ -406,6 +424,8 @@ class RecurringTransactionServiceTest {
             );
 
             assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
 
         @Test
@@ -432,6 +452,10 @@ class RecurringTransactionServiceTest {
                     .thenReturn(java.util.Optional.of(recurringTransaction));
             when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
             when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
+
+            doThrow(new IllegalArgumentException("Category type does not match transaction type"))
+                    .when(transactionCategoryValidator)
+                    .validate(category, TransactionType.EXPENSE);
 
             assertThatThrownBy(() -> recurringTransactionService.update(RECURRING_TRANSACTION_ID, request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -477,6 +501,7 @@ class RecurringTransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("End date cannot be before start date");
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
 
@@ -525,6 +550,7 @@ class RecurringTransactionServiceTest {
             assertThat(response.active()).isFalse();
             assertThat(recurringTransaction.isActive()).isFalse();
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
             verify(recurringTransactionRepository).save(recurringTransaction);
         }
     }

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -16,7 +16,7 @@ import com.financebot.recurring.repository.RecurringTransactionRepository;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
+import com.financebot.user.service.AuthenticatedUserResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -39,7 +39,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,7 +56,7 @@ class RecurringTransactionServiceTest {
     private RecurringTransactionMapper recurringTransactionMapper = new RecurringTransactionMapper();
 
     @Mock
-    private UserRepository userRepository;
+    private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Mock
     private AccountRepository accountRepository;
@@ -671,60 +670,8 @@ class RecurringTransactionServiceTest {
         }
     }
 
-    @Nested
-    @DisplayName("authentication")
-    class AuthenticationTests {
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication for nulo")
-        void shouldThrowWhenAuthenticationIsNull() {
-            assertThatThrownBy(() -> recurringTransactionService.findAll(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verifyNoInteractions(userRepository);
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication nao possuir nome")
-        void shouldThrowWhenAuthenticationNameIsNull() {
-            when(authentication.getName()).thenReturn(null);
-
-            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(any());
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication possuir nome em branco")
-        void shouldThrowWhenAuthenticationNameIsBlank() {
-            when(authentication.getName()).thenReturn("   ");
-
-            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(any());
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando usuario autenticado nao existir")
-        void shouldThrowWhenAuthenticatedUserDoesNotExist() {
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com"))
-                    .thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> recurringTransactionService.findAll(authentication))
-                    .isInstanceOf(EntityNotFoundException.class)
-                    .hasMessage("Authenticated user not found");
-        }
-    }
-
     private void mockAuthenticatedUser(User user) {
-        when(authentication.getName()).thenReturn(user.getEmail());
-        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
     }
 
     private CreateRecurringTransactionRequest buildCreateRequest() {

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -2,10 +2,8 @@ package com.financebot.recurring.service;
 
 import com.financebot.account.domain.Account;
 import com.financebot.account.domain.AccountType;
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.recurring.domain.RecurrenceFrequency;
 import com.financebot.recurring.domain.RecurringTransaction;
 import com.financebot.recurring.dto.request.CreateRecurringTransactionRequest;
@@ -17,6 +15,7 @@ import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -32,7 +31,6 @@ import org.springframework.security.core.Authentication;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -59,10 +57,7 @@ class RecurringTransactionServiceTest {
     private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Mock
-    private AccountRepository accountRepository;
-
-    @Mock
-    private CategoryRepository categoryRepository;
+    private UserResourceResolver userResourceResolver;
 
     @Mock
     private Authentication authentication;
@@ -84,10 +79,8 @@ class RecurringTransactionServiceTest {
             CreateRecurringTransactionRequest request = buildCreateRequest();
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
             when(recurringTransactionRepository.save(any(RecurringTransaction.class)))
                     .thenAnswer(invocation -> {
                         RecurringTransaction recurringTransaction = invocation.getArgument(0);
@@ -149,10 +142,8 @@ class RecurringTransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
             when(recurringTransactionRepository.save(any(RecurringTransaction.class)))
                     .thenAnswer(invocation -> invocation.getArgument(0));
 
@@ -171,10 +162,8 @@ class RecurringTransactionServiceTest {
             CreateRecurringTransactionRequest request = buildCreateRequest();
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
 
             assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -191,14 +180,14 @@ class RecurringTransactionServiceTest {
             CreateRecurringTransactionRequest request = buildCreateRequest();
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID))
+                    .thenThrow(new EntityNotFoundException("Account not found"));
 
             assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Account not found");
 
-            verify(categoryRepository, never()).findByIdAndUserId(any(), any());
+            verify(userResourceResolver, never()).resolveCategory(any(), any());
             verify(recurringTransactionRepository, never()).save(any(RecurringTransaction.class));
         }
 
@@ -211,10 +200,9 @@ class RecurringTransactionServiceTest {
             CreateRecurringTransactionRequest request = buildCreateRequest();
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID))
+                    .thenThrow(new EntityNotFoundException("Category not found"));
 
             assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -243,10 +231,8 @@ class RecurringTransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
 
             assertThatThrownBy(() -> recurringTransactionService.create(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -310,7 +296,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
 
             RecurringTransactionResponse response = recurringTransactionService.findById(
                     RECURRING_TRANSACTION_ID,
@@ -330,7 +316,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.empty());
+                    .thenReturn(java.util.Optional.empty());
 
             assertThatThrownBy(() -> recurringTransactionService.findById(RECURRING_TRANSACTION_ID, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -364,11 +350,9 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 
@@ -409,11 +393,9 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 
@@ -447,11 +429,9 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
 
             assertThatThrownBy(() -> recurringTransactionService.update(RECURRING_TRANSACTION_ID, request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -489,11 +469,9 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
 
             assertThatThrownBy(() -> recurringTransactionService.update(RECURRING_TRANSACTION_ID, request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -532,11 +510,9 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
-            when(accountRepository.findByIdAndUserId(ACCOUNT_ID, USER_ID))
-                    .thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(CATEGORY_ID, USER_ID))
-                    .thenReturn(Optional.of(category));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
+            when(userResourceResolver.resolveAccount(ACCOUNT_ID, USER_ID)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(CATEGORY_ID, USER_ID)).thenReturn(category);
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 
@@ -570,7 +546,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
 
             recurringTransactionService.delete(RECURRING_TRANSACTION_ID, authentication);
 
@@ -597,7 +573,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 
@@ -625,7 +601,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 
@@ -657,7 +633,7 @@ class RecurringTransactionServiceTest {
 
             mockAuthenticatedUser(user);
             when(recurringTransactionRepository.findByIdAndUserId(RECURRING_TRANSACTION_ID, USER_ID))
-                    .thenReturn(Optional.of(recurringTransaction));
+                    .thenReturn(java.util.Optional.of(recurringTransaction));
             when(recurringTransactionRepository.save(recurringTransaction))
                     .thenReturn(recurringTransaction);
 

--- a/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
+++ b/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
@@ -100,5 +100,22 @@ class InstallmentPlanFactoryTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");
         }
+
+        @Test
+        @DisplayName("deve preservar arredondamento half up e ajustar ultima parcela")
+        void shouldPreserveHalfUpRoundingAndAdjustLastInstallment() {
+            InstallmentPlan plan = installmentPlanFactory.create(
+                    new BigDecimal("10.01"),
+                    "Compra teste",
+                    LocalDate.of(2026, 4, 10),
+                    TransactionType.EXPENSE,
+                    2
+            );
+
+            assertThat(plan.items()).hasSize(2);
+
+            assertThat(plan.items().get(0).amount()).isEqualByComparingTo("5.01");
+            assertThat(plan.items().get(1).amount()).isEqualByComparingTo("5.00");
+        }
     }
 }

--- a/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
+++ b/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
@@ -1,0 +1,104 @@
+package com.financebot.transaction.domain.installment;
+
+import com.financebot.transaction.domain.TransactionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class InstallmentPlanFactoryTest {
+
+    private final InstallmentPlanFactory installmentPlanFactory = new InstallmentPlanFactory();
+
+    @Nested
+    @DisplayName("create")
+    class CreateTests {
+
+        @Test
+        @DisplayName("deve criar plano de parcelamento com valores, datas e descricoes corretas")
+        void shouldCreateInstallmentPlanSuccessfully() {
+            InstallmentPlan plan = installmentPlanFactory.create(
+                    new BigDecimal("1000.00"),
+                    "Notebook",
+                    LocalDate.of(2026, 4, 10),
+                    TransactionType.EXPENSE,
+                    3
+            );
+
+            assertThat(plan.installmentGroupId()).isNotBlank();
+            assertThat(plan.totalInstallments()).isEqualTo(3);
+            assertThat(plan.items()).hasSize(3);
+
+            assertThat(plan.items().get(0).amount()).isEqualByComparingTo("333.33");
+            assertThat(plan.items().get(1).amount()).isEqualByComparingTo("333.33");
+            assertThat(plan.items().get(2).amount()).isEqualByComparingTo("333.34");
+
+            assertThat(plan.items().get(0).description()).isEqualTo("Notebook - 1/3");
+            assertThat(plan.items().get(1).description()).isEqualTo("Notebook - 2/3");
+            assertThat(plan.items().get(2).description()).isEqualTo("Notebook - 3/3");
+
+            assertThat(plan.items().get(0).date()).isEqualTo(LocalDate.of(2026, 4, 10));
+            assertThat(plan.items().get(1).date()).isEqualTo(LocalDate.of(2026, 5, 10));
+            assertThat(plan.items().get(2).date()).isEqualTo(LocalDate.of(2026, 6, 10));
+
+            assertThat(plan.items().get(0).installmentNumber()).isEqualTo(1);
+            assertThat(plan.items().get(1).installmentNumber()).isEqualTo(2);
+            assertThat(plan.items().get(2).installmentNumber()).isEqualTo(3);
+
+            assertThat(plan.items().get(0).totalInstallments()).isEqualTo(3);
+            assertThat(plan.items().get(1).totalInstallments()).isEqualTo(3);
+            assertThat(plan.items().get(2).totalInstallments()).isEqualTo(3);
+
+            assertThat(plan.items().get(0).installmentGroupId()).isEqualTo(plan.installmentGroupId());
+            assertThat(plan.items().get(1).installmentGroupId()).isEqualTo(plan.installmentGroupId());
+            assertThat(plan.items().get(2).installmentGroupId()).isEqualTo(plan.installmentGroupId());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando tipo da transacao nao for despesa")
+        void shouldThrowWhenTransactionTypeIsNotExpense() {
+            assertThatThrownBy(() -> installmentPlanFactory.create(
+                    new BigDecimal("1000.00"),
+                    "Salário parcelado",
+                    LocalDate.of(2026, 4, 10),
+                    TransactionType.INCOME,
+                    3
+            ))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Installment transactions are allowed only for expenses");
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando total de parcelas for menor que dois")
+        void shouldThrowWhenTotalInstallmentsIsLessThanTwo() {
+            assertThatThrownBy(() -> installmentPlanFactory.create(
+                    new BigDecimal("1000.00"),
+                    "Notebook",
+                    LocalDate.of(2026, 4, 10),
+                    TransactionType.EXPENSE,
+                    1
+            ))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Total installments must be at least 2");
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando total de parcelas for nulo")
+        void shouldThrowWhenTotalInstallmentsIsNull() {
+            assertThatThrownBy(() -> installmentPlanFactory.create(
+                    new BigDecimal("1000.00"),
+                    "Notebook",
+                    LocalDate.of(2026, 4, 10),
+                    TransactionType.EXPENSE,
+                    null
+            ))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Total installments must be at least 2");
+        }
+    }
+}

--- a/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
@@ -17,7 +17,7 @@ import com.financebot.transaction.dto.response.TransactionResponse;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
-import com.financebot.user.repository.UserRepository;
+import com.financebot.user.service.AuthenticatedUserResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -44,7 +44,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -59,7 +58,7 @@ class TransactionServiceTest {
     private TransactionRepository transactionRepository;
 
     @Mock
-    private UserRepository userRepository;
+    private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Mock
     private AccountRepository accountRepository;
@@ -101,8 +100,7 @@ class TransactionServiceTest {
             Transaction savedTransaction = new Transaction();
             TransactionResponse response = mock(TransactionResponse.class);
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
             when(transactionMapper.toEntity(request)).thenReturn(transaction);
@@ -126,71 +124,6 @@ class TransactionServiceTest {
         }
 
         @Test
-        @DisplayName("deve lançar erro quando authentication for nulo")
-        void shouldThrowWhenAuthenticationIsNull() {
-            CreateTransactionRequest request = new CreateTransactionRequest(
-                    new BigDecimal("150.00"),
-                    "Mercado",
-                    LocalDate.of(2026, 4, 4),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L
-            );
-
-            assertThatThrownBy(() -> transactionService.create(request, null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verifyNoInteractions(userRepository, accountRepository, categoryRepository, transactionRepository, transactionMapper);
-        }
-
-        @Test
-        @DisplayName("deve lançar erro quando authentication não possuir nome")
-        void shouldThrowWhenAuthenticationNameIsNull() {
-            CreateTransactionRequest request = new CreateTransactionRequest(
-                    new BigDecimal("150.00"),
-                    "Mercado",
-                    LocalDate.of(2026, 4, 4),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L
-            );
-
-            when(authentication.getName()).thenReturn(null);
-
-            assertThatThrownBy(() -> transactionService.create(request, authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(anyString());
-        }
-
-        @Test
-        @DisplayName("deve lançar erro quando usuário autenticado não for encontrado")
-        void shouldThrowWhenAuthenticatedUserIsNotFound() {
-            CreateTransactionRequest request = new CreateTransactionRequest(
-                    new BigDecimal("150.00"),
-                    "Mercado",
-                    LocalDate.of(2026, 4, 4),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L
-            );
-
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> transactionService.create(request, authentication))
-                    .isInstanceOf(EntityNotFoundException.class)
-                    .hasMessage("Authenticated user not found");
-
-            verifyNoInteractions(accountRepository, categoryRepository, transactionRepository, transactionMapper);
-        }
-
-        @Test
         @DisplayName("deve lançar erro quando conta não pertencer ao usuário")
         void shouldThrowWhenAccountIsNotFoundForUser() {
             User user = buildUser(1L, "bryan@email.com");
@@ -205,8 +138,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> transactionService.create(request, authentication))
@@ -232,8 +164,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
 
@@ -261,8 +192,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
 
@@ -271,28 +201,6 @@ class TransactionServiceTest {
                     .hasMessage("Category type does not match transaction type");
 
             verifyNoInteractions(transactionRepository, transactionMapper);
-        }
-
-        @Test
-        @DisplayName("deve lançar erro quando authentication possuir nome em branco")
-        void shouldThrowWhenAuthenticationNameIsBlank() {
-            CreateTransactionRequest request = new CreateTransactionRequest(
-                    new BigDecimal("150.00"),
-                    "Mercado",
-                    LocalDate.of(2026, 4, 4),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L
-            );
-
-            when(authentication.getName()).thenReturn("   ");
-
-            assertThatThrownBy(() -> transactionService.create(request, authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(anyString());
         }
     }
 
@@ -344,8 +252,7 @@ class TransactionServiceTest {
                     3
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -371,58 +278,11 @@ class TransactionServiceTest {
                     1
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");
-
-            verifyNoInteractions(accountRepository, categoryRepository, transactionMapper);
-            verify(transactionRepository, never()).saveAll(anyList());
-        }
-
-        @Test
-        @DisplayName("deve lançar erro quando authentication for nulo no parcelamento")
-        void shouldThrowWhenAuthenticationIsNullOnCreateInstallment() {
-            CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L,
-                    3
-            );
-
-            assertThatThrownBy(() -> transactionService.createInstallment(request, null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verifyNoInteractions(userRepository, accountRepository, categoryRepository, transactionRepository, transactionMapper);
-        }
-
-        @Test
-        @DisplayName("deve lançar erro quando usuário autenticado não for encontrado no parcelamento")
-        void shouldThrowWhenAuthenticatedUserIsNotFoundOnCreateInstallment() {
-            CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L,
-                    3
-            );
-
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
-                    .isInstanceOf(EntityNotFoundException.class)
-                    .hasMessage("Authenticated user not found");
 
             verifyNoInteractions(accountRepository, categoryRepository, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
@@ -444,8 +304,7 @@ class TransactionServiceTest {
                     3
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
@@ -473,8 +332,7 @@ class TransactionServiceTest {
                     3
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
 
@@ -504,8 +362,7 @@ class TransactionServiceTest {
                     3
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
 
@@ -552,7 +409,7 @@ class TransactionServiceTest {
         assertThat(result.totalInstallments()).isEqualTo(3);
         assertThat(result.transactions()).containsExactly(response1, response2, response3);
 
-        verify(userRepository, never()).findByEmail(anyString());
+        verify(authenticatedUserResolver, never()).resolve(any());
     }
 
     @Nested
@@ -580,8 +437,7 @@ class TransactionServiceTest {
 
             Page<Transaction> page = new PageImpl<>(List.of(transaction), pageable, 1);
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(page);
             when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
@@ -611,8 +467,7 @@ class TransactionServiceTest {
 
             Pageable pageable = PageRequest.of(0, 10);
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
 
             assertThatThrownBy(() -> transactionService.findAll(filter, authentication, pageable))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -634,8 +489,7 @@ class TransactionServiceTest {
             Transaction transaction = new Transaction();
             TransactionResponse response = mock(TransactionResponse.class);
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(Optional.of(transaction));
             when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
@@ -650,8 +504,7 @@ class TransactionServiceTest {
         void shouldThrowWhenTransactionIsNotFound() {
             User user = buildUser(1L, "bryan@email.com");
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> transactionService.findById(99L, authentication))
@@ -685,8 +538,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
@@ -719,8 +571,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
@@ -746,8 +597,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
 
@@ -777,8 +627,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
@@ -809,8 +658,7 @@ class TransactionServiceTest {
                     20L
             );
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
             when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
             when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
@@ -834,8 +682,7 @@ class TransactionServiceTest {
             User user = buildUser(1L, "bryan@email.com");
             Transaction transaction = new Transaction();
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(Optional.of(transaction));
 
             transactionService.delete(55L, authentication);
@@ -848,8 +695,7 @@ class TransactionServiceTest {
         void shouldThrowWhenTransactionToDeleteDoesNotExist() {
             User user = buildUser(1L, "bryan@email.com");
 
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+            mockAuthenticatedUser(user);
             when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(Optional.empty());
 
             assertThatThrownBy(() -> transactionService.delete(55L, authentication))
@@ -858,6 +704,10 @@ class TransactionServiceTest {
 
             verify(transactionRepository, never()).delete(any(Transaction.class));
         }
+    }
+
+    private void mockAuthenticatedUser(User user) {
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
     }
 
     private CreateInstallmentTransactionRequest buildInstallmentRequest() {
@@ -882,8 +732,7 @@ class TransactionServiceTest {
             TransactionResponse response2,
             TransactionResponse response3
     ) {
-        when(authentication.getName()).thenReturn("bryan@email.com");
-        when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+        mockAuthenticatedUser(user);
         when(accountRepository.findByIdAndUserId(request.accountId(), user.getId())).thenReturn(Optional.of(account));
         when(categoryRepository.findByIdAndUserId(request.categoryId(), user.getId())).thenReturn(Optional.of(category));
         when(transactionRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));

--- a/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
@@ -1,10 +1,8 @@
 package com.financebot.transaction.service;
 
 import com.financebot.account.domain.Account;
-import com.financebot.account.repository.AccountRepository;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.category.repository.CategoryRepository;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
@@ -18,6 +16,7 @@ import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
+import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,7 +37,6 @@ import org.springframework.security.core.Authentication;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -61,10 +59,7 @@ class TransactionServiceTest {
     private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Mock
-    private AccountRepository accountRepository;
-
-    @Mock
-    private CategoryRepository categoryRepository;
+    private UserResourceResolver userResourceResolver;
 
     @Mock
     private TransactionMapper transactionMapper;
@@ -101,8 +96,8 @@ class TransactionServiceTest {
             TransactionResponse response = mock(TransactionResponse.class);
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
             when(transactionMapper.toEntity(request)).thenReturn(transaction);
             when(transactionRepository.save(transaction)).thenReturn(savedTransaction);
             when(transactionMapper.toResponse(savedTransaction)).thenReturn(response);
@@ -139,13 +134,15 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(10L, 1L))
+                    .thenThrow(new EntityNotFoundException("Account not found"));
 
             assertThatThrownBy(() -> transactionService.create(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Account not found");
 
-            verifyNoInteractions(categoryRepository, transactionRepository, transactionMapper);
+            verify(userResourceResolver, never()).resolveCategory(any(), any());
+            verifyNoInteractions(transactionRepository, transactionMapper);
         }
 
         @Test
@@ -165,8 +162,9 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L))
+                    .thenThrow(new EntityNotFoundException("Category not found"));
 
             assertThatThrownBy(() -> transactionService.create(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -193,8 +191,8 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
 
             assertThatThrownBy(() -> transactionService.create(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -258,7 +256,7 @@ class TransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Installment transactions are allowed only for expenses");
 
-            verifyNoInteractions(accountRepository, categoryRepository, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -284,7 +282,7 @@ class TransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");
 
-            verifyNoInteractions(accountRepository, categoryRepository, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -305,13 +303,15 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(10L, 1L))
+                    .thenThrow(new EntityNotFoundException("Account not found"));
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Account not found");
 
-            verifyNoInteractions(categoryRepository, transactionMapper);
+            verify(userResourceResolver, never()).resolveCategory(any(), any());
+            verifyNoInteractions(transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -333,8 +333,9 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L))
+                    .thenThrow(new EntityNotFoundException("Category not found"));
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -363,8 +364,8 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -388,11 +389,11 @@ class TransactionServiceTest {
         TransactionResponse response2 = mock(TransactionResponse.class);
         TransactionResponse response3 = mock(TransactionResponse.class);
 
-        when(accountRepository.findByIdAndUserId(request.accountId(), user.getId()))
-                .thenReturn(Optional.of(account));
+        when(userResourceResolver.resolveAccount(request.accountId(), user.getId()))
+                .thenReturn(account);
 
-        when(categoryRepository.findByIdAndUserId(request.categoryId(), user.getId()))
-                .thenReturn(Optional.of(category));
+        when(userResourceResolver.resolveCategory(request.categoryId(), user.getId()))
+                .thenReturn(category);
 
         when(transactionRepository.saveAll(anyList()))
                 .thenAnswer(invocation -> invocation.getArgument(0));
@@ -490,7 +491,7 @@ class TransactionServiceTest {
             TransactionResponse response = mock(TransactionResponse.class);
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(Optional.of(transaction));
+            when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(java.util.Optional.of(transaction));
             when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
             TransactionResponse result = transactionService.findById(99L, authentication);
@@ -505,7 +506,7 @@ class TransactionServiceTest {
             User user = buildUser(1L, "bryan@email.com");
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(Optional.empty());
+            when(transactionRepository.findByIdAndUserId(99L, 1L)).thenReturn(java.util.Optional.empty());
 
             assertThatThrownBy(() -> transactionService.findById(99L, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -539,9 +540,9 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
+            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.of(transaction));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
             when(transactionRepository.save(transaction)).thenReturn(transaction);
             when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
@@ -572,13 +573,13 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.empty());
+            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.empty());
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Transaction not found");
 
-            verifyNoInteractions(accountRepository, categoryRepository, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionMapper);
         }
 
         @Test
@@ -598,14 +599,15 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.empty());
+            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.of(transaction));
+            when(userResourceResolver.resolveAccount(10L, 1L))
+                    .thenThrow(new EntityNotFoundException("Account not found"));
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Account not found");
 
-            verifyNoInteractions(categoryRepository);
+            verify(userResourceResolver, never()).resolveCategory(any(), any());
             verify(transactionMapper, never()).updateEntity(any(), any());
             verify(transactionRepository, never()).save(any());
         }
@@ -628,9 +630,10 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.empty());
+            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.of(transaction));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L))
+                    .thenThrow(new EntityNotFoundException("Category not found"));
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -659,9 +662,9 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
-            when(accountRepository.findByIdAndUserId(10L, 1L)).thenReturn(Optional.of(account));
-            when(categoryRepository.findByIdAndUserId(20L, 1L)).thenReturn(Optional.of(category));
+            when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.of(transaction));
+            when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+            when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -683,7 +686,7 @@ class TransactionServiceTest {
             Transaction transaction = new Transaction();
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(Optional.of(transaction));
+            when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(java.util.Optional.of(transaction));
 
             transactionService.delete(55L, authentication);
 
@@ -696,7 +699,7 @@ class TransactionServiceTest {
             User user = buildUser(1L, "bryan@email.com");
 
             mockAuthenticatedUser(user);
-            when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(Optional.empty());
+            when(transactionRepository.findByIdAndUserId(55L, 1L)).thenReturn(java.util.Optional.empty());
 
             assertThatThrownBy(() -> transactionService.delete(55L, authentication))
                     .isInstanceOf(EntityNotFoundException.class)
@@ -733,8 +736,8 @@ class TransactionServiceTest {
             TransactionResponse response3
     ) {
         mockAuthenticatedUser(user);
-        when(accountRepository.findByIdAndUserId(request.accountId(), user.getId())).thenReturn(Optional.of(account));
-        when(categoryRepository.findByIdAndUserId(request.categoryId(), user.getId())).thenReturn(Optional.of(category));
+        when(userResourceResolver.resolveAccount(request.accountId(), user.getId())).thenReturn(account);
+        when(userResourceResolver.resolveCategory(request.categoryId(), user.getId())).thenReturn(category);
         when(transactionRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         when(transactionMapper.toResponse(any(Transaction.class)))

--- a/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
@@ -6,6 +6,9 @@ import com.financebot.category.domain.CategoryType;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
+import com.financebot.transaction.domain.installment.InstallmentPlan;
+import com.financebot.transaction.domain.installment.InstallmentPlanFactory;
+import com.financebot.transaction.domain.installment.InstallmentPlanItem;
 import com.financebot.transaction.dto.TransactionFilter;
 import com.financebot.transaction.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.dto.request.CreateTransactionRequest;
@@ -54,6 +57,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class TransactionServiceTest {
 
+    private static final String INSTALLMENT_GROUP_ID = "installment-group-123";
+
     @Mock
     private TransactionRepository transactionRepository;
 
@@ -65,6 +70,9 @@ class TransactionServiceTest {
 
     @Mock
     private TransactionCategoryValidator transactionCategoryValidator;
+
+    @Mock
+    private InstallmentPlanFactory installmentPlanFactory;
 
     @Mock
     private TransactionMapper transactionMapper;
@@ -217,8 +225,8 @@ class TransactionServiceTest {
     class CreateInstallmentTests {
 
         @Test
-        @DisplayName("deve criar parcelamento com sucesso e ajustar a última parcela")
-        void shouldCreateInstallmentSuccessfullyWithRoundingAdjustment() {
+        @DisplayName("deve criar parcelamento com sucesso a partir do plano de dominio")
+        void shouldCreateInstallmentSuccessfullyFromDomainPlan() {
             User user = buildUser(1L, "bryan@email.com");
             Account account = buildAccount(10L);
             Category category = buildCategory(20L, CategoryType.EXPENSE);
@@ -229,6 +237,7 @@ class TransactionServiceTest {
             TransactionResponse response2 = mock(TransactionResponse.class);
             TransactionResponse response3 = mock(TransactionResponse.class);
 
+            mockAuthenticatedUser(user);
             mockInstallmentCreationDependencies(user, account, category, request, response1, response2, response3);
 
             InstallmentTransactionResponse result =
@@ -243,12 +252,19 @@ class TransactionServiceTest {
             assertInstallmentMetadata(savedTransactions, result);
             assertInstallmentResponse(result, response1, response2, response3);
 
+            verify(installmentPlanFactory).create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            );
             verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
 
         @Test
-        @DisplayName("deve lançar erro quando tentar parcelar uma receita")
-        void shouldThrowWhenTryingToCreateInstallmentForIncome() {
+        @DisplayName("deve lançar erro quando plano de parcelamento rejeitar receita")
+        void shouldThrowWhenInstallmentPlanRejectsIncomeTransaction() {
             User user = buildUser(1L, "bryan@email.com");
 
             CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
@@ -263,6 +279,13 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
+            when(installmentPlanFactory.create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            )).thenThrow(new IllegalArgumentException("Installment transactions are allowed only for expenses"));
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -273,8 +296,8 @@ class TransactionServiceTest {
         }
 
         @Test
-        @DisplayName("deve lançar erro quando total de parcelas for menor que 2")
-        void shouldThrowWhenTotalInstallmentsIsLessThanTwo() {
+        @DisplayName("deve lançar erro quando plano de parcelamento rejeitar total menor que dois")
+        void shouldThrowWhenInstallmentPlanRejectsTotalInstallmentsLessThanTwo() {
             User user = buildUser(1L, "bryan@email.com");
 
             CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
@@ -289,6 +312,13 @@ class TransactionServiceTest {
             );
 
             mockAuthenticatedUser(user);
+            when(installmentPlanFactory.create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            )).thenThrow(new IllegalArgumentException("Total installments must be at least 2"));
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -303,18 +333,17 @@ class TransactionServiceTest {
         void shouldThrowWhenAccountIsNotFoundForUserOnCreateInstallment() {
             User user = buildUser(1L, "bryan@email.com");
 
-            CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L,
-                    3
-            );
+            CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+            InstallmentPlan plan = buildInstallmentPlan();
 
             mockAuthenticatedUser(user);
+            when(installmentPlanFactory.create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            )).thenReturn(plan);
             when(userResourceResolver.resolveAccount(10L, 1L))
                     .thenThrow(new EntityNotFoundException("Account not found"));
 
@@ -333,18 +362,17 @@ class TransactionServiceTest {
             User user = buildUser(1L, "bryan@email.com");
             Account account = buildAccount(10L);
 
-            CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L,
-                    3
-            );
+            CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+            InstallmentPlan plan = buildInstallmentPlan();
 
             mockAuthenticatedUser(user);
+            when(installmentPlanFactory.create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            )).thenReturn(plan);
             when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
             when(userResourceResolver.resolveCategory(20L, 1L))
                     .thenThrow(new EntityNotFoundException("Category not found"));
@@ -364,18 +392,17 @@ class TransactionServiceTest {
             Account account = buildAccount(10L);
             Category category = buildCategory(20L, CategoryType.INCOME);
 
-            CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    SourceType.WEB,
-                    10L,
-                    20L,
-                    3
-            );
+            CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+            InstallmentPlan plan = buildInstallmentPlan();
 
             mockAuthenticatedUser(user);
+            when(installmentPlanFactory.create(
+                    request.totalAmount(),
+                    request.description(),
+                    request.firstInstallmentDate(),
+                    request.type(),
+                    request.totalInstallments()
+            )).thenReturn(plan);
             when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
             when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
 
@@ -405,17 +432,7 @@ class TransactionServiceTest {
         TransactionResponse response2 = mock(TransactionResponse.class);
         TransactionResponse response3 = mock(TransactionResponse.class);
 
-        when(userResourceResolver.resolveAccount(request.accountId(), user.getId()))
-                .thenReturn(account);
-
-        when(userResourceResolver.resolveCategory(request.categoryId(), user.getId()))
-                .thenReturn(category);
-
-        when(transactionRepository.saveAll(anyList()))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        when(transactionMapper.toResponse(any(Transaction.class)))
-                .thenReturn(response1, response2, response3);
+        mockInstallmentCreationDependencies(user, account, category, request, response1, response2, response3);
 
         InstallmentTransactionResponse result =
                 transactionService.createInstallmentForUser(request, user);
@@ -424,8 +441,16 @@ class TransactionServiceTest {
 
         assertThat(savedTransactions).hasSize(3);
         assertThat(result.totalInstallments()).isEqualTo(3);
+        assertThat(result.installmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
         assertThat(result.transactions()).containsExactly(response1, response2, response3);
 
+        verify(installmentPlanFactory).create(
+                request.totalAmount(),
+                request.description(),
+                request.firstInstallmentDate(),
+                request.type(),
+                request.totalInstallments()
+        );
         verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         verify(authenticatedUserResolver, never()).resolve(any());
     }
@@ -759,13 +784,58 @@ class TransactionServiceTest {
             TransactionResponse response2,
             TransactionResponse response3
     ) {
-        mockAuthenticatedUser(user);
+        InstallmentPlan plan = buildInstallmentPlan();
+
+        when(installmentPlanFactory.create(
+                request.totalAmount(),
+                request.description(),
+                request.firstInstallmentDate(),
+                request.type(),
+                request.totalInstallments()
+        )).thenReturn(plan);
+
         when(userResourceResolver.resolveAccount(request.accountId(), user.getId())).thenReturn(account);
         when(userResourceResolver.resolveCategory(request.categoryId(), user.getId())).thenReturn(category);
+
         when(transactionRepository.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 
         when(transactionMapper.toResponse(any(Transaction.class)))
                 .thenReturn(response1, response2, response3);
+    }
+
+    private InstallmentPlan buildInstallmentPlan() {
+        List<InstallmentPlanItem> items = List.of(
+                new InstallmentPlanItem(
+                        new BigDecimal("333.33"),
+                        "Notebook - 1/3",
+                        LocalDate.of(2026, 4, 10),
+                        1,
+                        3,
+                        INSTALLMENT_GROUP_ID
+                ),
+                new InstallmentPlanItem(
+                        new BigDecimal("333.33"),
+                        "Notebook - 2/3",
+                        LocalDate.of(2026, 5, 10),
+                        2,
+                        3,
+                        INSTALLMENT_GROUP_ID
+                ),
+                new InstallmentPlanItem(
+                        new BigDecimal("333.34"),
+                        "Notebook - 3/3",
+                        LocalDate.of(2026, 6, 10),
+                        3,
+                        3,
+                        INSTALLMENT_GROUP_ID
+                )
+        );
+
+        return new InstallmentPlan(
+                INSTALLMENT_GROUP_ID,
+                3,
+                items
+        );
     }
 
     private List<Transaction> captureSavedInstallments() {
@@ -830,11 +900,11 @@ class TransactionServiceTest {
         assertThat(second.getTotalInstallments()).isEqualTo(3);
         assertThat(third.getTotalInstallments()).isEqualTo(3);
 
-        assertThat(first.getInstallmentGroupId()).isNotBlank();
-        assertThat(second.getInstallmentGroupId()).isEqualTo(first.getInstallmentGroupId());
-        assertThat(third.getInstallmentGroupId()).isEqualTo(first.getInstallmentGroupId());
+        assertThat(first.getInstallmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
+        assertThat(second.getInstallmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
+        assertThat(third.getInstallmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
 
-        assertThat(result.installmentGroupId()).isEqualTo(first.getInstallmentGroupId());
+        assertThat(result.installmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
     }
 
     private void assertInstallmentResponse(
@@ -843,6 +913,7 @@ class TransactionServiceTest {
             TransactionResponse response2,
             TransactionResponse response3
     ) {
+        assertThat(result.installmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
         assertThat(result.totalInstallments()).isEqualTo(3);
         assertThat(result.transactions()).containsExactly(response1, response2, response3);
     }

--- a/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
+++ b/src/test/java/com/financebot/transaction/service/TransactionServiceTest.java
@@ -14,6 +14,7 @@ import com.financebot.transaction.dto.response.InstallmentTransactionResponse;
 import com.financebot.transaction.dto.response.TransactionResponse;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.repository.TransactionRepository;
+import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
@@ -43,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -60,6 +62,9 @@ class TransactionServiceTest {
 
     @Mock
     private UserResourceResolver userResourceResolver;
+
+    @Mock
+    private TransactionCategoryValidator transactionCategoryValidator;
 
     @Mock
     private TransactionMapper transactionMapper;
@@ -113,6 +118,7 @@ class TransactionServiceTest {
             assertThat(transaction.getTotalInstallments()).isNull();
             assertThat(transaction.getInstallmentGroupId()).isNull();
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
             verify(transactionMapper).toEntity(request);
             verify(transactionRepository).save(transaction);
             verify(transactionMapper).toResponse(savedTransaction);
@@ -142,7 +148,7 @@ class TransactionServiceTest {
                     .hasMessage("Account not found");
 
             verify(userResourceResolver, never()).resolveCategory(any(), any());
-            verifyNoInteractions(transactionRepository, transactionMapper);
+            verifyNoInteractions(transactionCategoryValidator, transactionRepository, transactionMapper);
         }
 
         @Test
@@ -170,7 +176,7 @@ class TransactionServiceTest {
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Category not found");
 
-            verifyNoInteractions(transactionRepository, transactionMapper);
+            verifyNoInteractions(transactionCategoryValidator, transactionRepository, transactionMapper);
         }
 
         @Test
@@ -193,6 +199,10 @@ class TransactionServiceTest {
             mockAuthenticatedUser(user);
             when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
             when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
+
+            doThrow(new IllegalArgumentException("Category type does not match transaction type"))
+                    .when(transactionCategoryValidator)
+                    .validate(category, TransactionType.EXPENSE);
 
             assertThatThrownBy(() -> transactionService.create(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -232,6 +242,8 @@ class TransactionServiceTest {
             assertInstallmentCommonData(savedTransactions, user, account, category);
             assertInstallmentMetadata(savedTransactions, result);
             assertInstallmentResponse(result, response1, response2, response3);
+
+            verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
 
         @Test
@@ -256,7 +268,7 @@ class TransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Installment transactions are allowed only for expenses");
 
-            verifyNoInteractions(userResourceResolver, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionCategoryValidator, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -282,7 +294,7 @@ class TransactionServiceTest {
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");
 
-            verifyNoInteractions(userResourceResolver, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionCategoryValidator, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -311,7 +323,7 @@ class TransactionServiceTest {
                     .hasMessage("Account not found");
 
             verify(userResourceResolver, never()).resolveCategory(any(), any());
-            verifyNoInteractions(transactionMapper);
+            verifyNoInteractions(transactionCategoryValidator, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -341,7 +353,7 @@ class TransactionServiceTest {
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Category not found");
 
-            verifyNoInteractions(transactionMapper);
+            verifyNoInteractions(transactionCategoryValidator, transactionMapper);
             verify(transactionRepository, never()).saveAll(anyList());
         }
 
@@ -366,6 +378,10 @@ class TransactionServiceTest {
             mockAuthenticatedUser(user);
             when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
             when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
+
+            doThrow(new IllegalArgumentException("Category type does not match transaction type"))
+                    .when(transactionCategoryValidator)
+                    .validate(category, TransactionType.EXPENSE);
 
             assertThatThrownBy(() -> transactionService.createInstallment(request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)
@@ -410,6 +426,7 @@ class TransactionServiceTest {
         assertThat(result.totalInstallments()).isEqualTo(3);
         assertThat(result.transactions()).containsExactly(response1, response2, response3);
 
+        verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         verify(authenticatedUserResolver, never()).resolve(any());
     }
 
@@ -552,6 +569,7 @@ class TransactionServiceTest {
             assertThat(transaction.getAccount()).isEqualTo(account);
             assertThat(transaction.getCategory()).isEqualTo(category);
 
+            verify(transactionCategoryValidator).validate(category, TransactionType.INCOME);
             verify(transactionMapper).updateEntity(request, transaction);
             verify(transactionRepository).save(transaction);
             verify(transactionMapper).toResponse(transaction);
@@ -579,7 +597,7 @@ class TransactionServiceTest {
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Transaction not found");
 
-            verifyNoInteractions(userResourceResolver, transactionMapper);
+            verifyNoInteractions(userResourceResolver, transactionCategoryValidator, transactionMapper);
         }
 
         @Test
@@ -608,6 +626,7 @@ class TransactionServiceTest {
                     .hasMessage("Account not found");
 
             verify(userResourceResolver, never()).resolveCategory(any(), any());
+            verifyNoInteractions(transactionCategoryValidator);
             verify(transactionMapper, never()).updateEntity(any(), any());
             verify(transactionRepository, never()).save(any());
         }
@@ -639,6 +658,7 @@ class TransactionServiceTest {
                     .isInstanceOf(EntityNotFoundException.class)
                     .hasMessage("Category not found");
 
+            verifyNoInteractions(transactionCategoryValidator);
             verify(transactionMapper, never()).updateEntity(any(), any());
             verify(transactionRepository, never()).save(any());
         }
@@ -665,6 +685,10 @@ class TransactionServiceTest {
             when(transactionRepository.findByIdAndUserId(77L, 1L)).thenReturn(java.util.Optional.of(transaction));
             when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
             when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
+
+            doThrow(new IllegalArgumentException("Category type does not match transaction type"))
+                    .when(transactionCategoryValidator)
+                    .validate(category, TransactionType.INCOME);
 
             assertThatThrownBy(() -> transactionService.update(77L, request, authentication))
                     .isInstanceOf(IllegalArgumentException.class)

--- a/src/test/java/com/financebot/transaction/validation/TransactionCategoryValidatorTest.java
+++ b/src/test/java/com/financebot/transaction/validation/TransactionCategoryValidatorTest.java
@@ -1,0 +1,70 @@
+package com.financebot.transaction.validation;
+
+import com.financebot.category.domain.Category;
+import com.financebot.category.domain.CategoryType;
+import com.financebot.transaction.domain.TransactionType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionCategoryValidatorTest {
+
+    @InjectMocks
+    private TransactionCategoryValidator transactionCategoryValidator;
+
+    @Nested
+    @DisplayName("validate")
+    class ValidateTests {
+
+        @Test
+        @DisplayName("deve aceitar categoria de despesa para transacao de despesa")
+        void shouldAcceptExpenseCategoryForExpenseTransaction() {
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            assertThatCode(() -> transactionCategoryValidator.validate(category, TransactionType.EXPENSE))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("deve aceitar categoria de receita para transacao de receita")
+        void shouldAcceptIncomeCategoryForIncomeTransaction() {
+            Category category = buildCategory(CategoryType.INCOME);
+
+            assertThatCode(() -> transactionCategoryValidator.validate(category, TransactionType.INCOME))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria de receita for usada em despesa")
+        void shouldThrowWhenIncomeCategoryIsUsedForExpenseTransaction() {
+            Category category = buildCategory(CategoryType.INCOME);
+
+            assertThatThrownBy(() -> transactionCategoryValidator.validate(category, TransactionType.EXPENSE))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Category type does not match transaction type");
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria de despesa for usada em receita")
+        void shouldThrowWhenExpenseCategoryIsUsedForIncomeTransaction() {
+            Category category = buildCategory(CategoryType.EXPENSE);
+
+            assertThatThrownBy(() -> transactionCategoryValidator.validate(category, TransactionType.INCOME))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Category type does not match transaction type");
+        }
+    }
+
+    private Category buildCategory(CategoryType type) {
+        Category category = new Category();
+        category.setType(type);
+        return category;
+    }
+}

--- a/src/test/java/com/financebot/user/service/AuthenticatedUserResolverTest.java
+++ b/src/test/java/com/financebot/user/service/AuthenticatedUserResolverTest.java
@@ -1,0 +1,100 @@
+package com.financebot.user.service;
+
+import com.financebot.user.domain.User;
+import com.financebot.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticatedUserResolverTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private Authentication authentication;
+
+    @InjectMocks
+    private AuthenticatedUserResolver authenticatedUserResolver;
+
+    @Nested
+    @DisplayName("resolve")
+    class ResolveTests {
+
+        @Test
+        @DisplayName("deve retornar usuario autenticado quando authentication for valida")
+        void shouldResolveAuthenticatedUser() {
+            User user = new User();
+            user.setId(1L);
+            user.setEmail("bryan@email.com");
+
+            when(authentication.getName()).thenReturn("bryan@email.com");
+            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.of(user));
+
+            User result = authenticatedUserResolver.resolve(authentication);
+
+            assertThat(result).isEqualTo(user);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication for nulo")
+        void shouldThrowWhenAuthenticationIsNull() {
+            assertThatThrownBy(() -> authenticatedUserResolver.resolve(null))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(anyString());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication nao possuir nome")
+        void shouldThrowWhenAuthenticationNameIsNull() {
+            when(authentication.getName()).thenReturn(null);
+
+            assertThatThrownBy(() -> authenticatedUserResolver.resolve(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(anyString());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando authentication possuir nome em branco")
+        void shouldThrowWhenAuthenticationNameIsBlank() {
+            when(authentication.getName()).thenReturn("   ");
+
+            assertThatThrownBy(() -> authenticatedUserResolver.resolve(authentication))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("Authenticated user is invalid");
+
+            verify(userRepository, never()).findByEmail(anyString());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando usuario autenticado nao existir")
+        void shouldThrowWhenAuthenticatedUserDoesNotExist() {
+            when(authentication.getName()).thenReturn("bryan@email.com");
+            when(userRepository.findByEmail("bryan@email.com")).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> authenticatedUserResolver.resolve(authentication))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Authenticated user not found");
+        }
+    }
+}

--- a/src/test/java/com/financebot/user/service/UserResourceResolverTest.java
+++ b/src/test/java/com/financebot/user/service/UserResourceResolverTest.java
@@ -1,0 +1,93 @@
+package com.financebot.user.service;
+
+import com.financebot.account.domain.Account;
+import com.financebot.account.repository.AccountRepository;
+import com.financebot.category.domain.Category;
+import com.financebot.category.repository.CategoryRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserResourceResolverTest {
+
+    @Mock
+    private AccountRepository accountRepository;
+
+    @Mock
+    private CategoryRepository categoryRepository;
+
+    @InjectMocks
+    private UserResourceResolver userResourceResolver;
+
+    @Nested
+    @DisplayName("resolveAccount")
+    class ResolveAccountTests {
+
+        @Test
+        @DisplayName("deve retornar conta quando ela pertencer ao usuario")
+        void shouldResolveAccount() {
+            Account account = new Account();
+            account.setId(10L);
+
+            when(accountRepository.findByIdAndUserId(10L, 1L))
+                    .thenReturn(Optional.of(account));
+
+            Account result = userResourceResolver.resolveAccount(10L, 1L);
+
+            assertThat(result).isEqualTo(account);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando conta nao pertencer ao usuario")
+        void shouldThrowWhenAccountDoesNotBelongToUser() {
+            when(accountRepository.findByIdAndUserId(10L, 1L))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userResourceResolver.resolveAccount(10L, 1L))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Account not found");
+        }
+    }
+
+    @Nested
+    @DisplayName("resolveCategory")
+    class ResolveCategoryTests {
+
+        @Test
+        @DisplayName("deve retornar categoria quando ela pertencer ao usuario")
+        void shouldResolveCategory() {
+            Category category = new Category();
+            category.setId(20L);
+
+            when(categoryRepository.findByIdAndUserId(20L, 1L))
+                    .thenReturn(Optional.of(category));
+
+            Category result = userResourceResolver.resolveCategory(20L, 1L);
+
+            assertThat(result).isEqualTo(category);
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando categoria nao pertencer ao usuario")
+        void shouldThrowWhenCategoryDoesNotBelongToUser() {
+            when(categoryRepository.findByIdAndUserId(20L, 1L))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> userResourceResolver.resolveCategory(20L, 1L))
+                    .isInstanceOf(EntityNotFoundException.class)
+                    .hasMessage("Category not found");
+        }
+    }
+}

--- a/src/test/java/com/financebot/user/service/UserServiceTest.java
+++ b/src/test/java/com/financebot/user/service/UserServiceTest.java
@@ -30,7 +30,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +40,9 @@ class UserServiceTest {
 
     @Mock
     private Authentication authentication;
+
+    @Mock
+    private AuthenticatedUserResolver authenticatedUserResolver;
 
     @Spy
     private UserMapper userMapper = new UserMapper();
@@ -75,6 +77,8 @@ class UserServiceTest {
             assertThat(response.telegramLinked()).isTrue();
             assertThat(response.telegramLinkCode()).isEqualTo("FIN-ABC123");
             assertThat(response.telegramLinkCodeExpiresAt()).isEqualTo(user.getTelegramLinkCodeExpiresAt());
+
+            verify(authenticatedUserResolver).resolve(authentication);
         }
 
         @Test
@@ -89,6 +93,8 @@ class UserServiceTest {
 
             assertThat(response.telegramLinked()).isFalse();
             assertThat(response.telegramId()).isNull();
+
+            verify(authenticatedUserResolver).resolve(authentication);
         }
     }
 
@@ -116,6 +122,8 @@ class UserServiceTest {
 
             assertThat(savedUser).isEqualTo(user);
             assertThat(savedUser.getMonthlyBaseIncome()).isEqualByComparingTo("4200.00");
+
+            verify(authenticatedUserResolver).resolve(authentication);
         }
     }
 
@@ -140,6 +148,8 @@ class UserServiceTest {
 
             assertThat(savedUser).isEqualTo(user);
             assertThat(savedUser.getOnboardingCompleted()).isTrue();
+
+            verify(authenticatedUserResolver).resolve(authentication);
         }
     }
 
@@ -168,6 +178,8 @@ class UserServiceTest {
 
             assertThat(savedUser.getTelegramLinkCode()).isEqualTo(response.telegramLinkCode());
             assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isEqualTo(response.expiresAt());
+
+            verify(authenticatedUserResolver).resolve(authentication);
         }
     }
 
@@ -359,63 +371,13 @@ class UserServiceTest {
             assertThat(savedUser.getTelegramId()).isNull();
             assertThat(savedUser.getTelegramLinkCode()).isNull();
             assertThat(savedUser.getTelegramLinkCodeExpiresAt()).isNull();
-        }
-    }
 
-    @Nested
-    @DisplayName("authentication")
-    class AuthenticationTests {
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication for nulo")
-        void shouldThrowWhenAuthenticationIsNull() {
-            assertThatThrownBy(() -> userService.getMe(null))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verifyNoInteractions(userRepository);
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication nao possuir nome")
-        void shouldThrowWhenAuthenticationNameIsNull() {
-            when(authentication.getName()).thenReturn(null);
-
-            assertThatThrownBy(() -> userService.getMe(authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(any());
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando authentication possuir nome em branco")
-        void shouldThrowWhenAuthenticationNameIsBlank() {
-            when(authentication.getName()).thenReturn("   ");
-
-            assertThatThrownBy(() -> userService.getMe(authentication))
-                    .isInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Authenticated user is invalid");
-
-            verify(userRepository, never()).findByEmail(any());
-        }
-
-        @Test
-        @DisplayName("deve lancar erro quando usuario autenticado nao for encontrado")
-        void shouldThrowWhenAuthenticatedUserIsNotFound() {
-            when(authentication.getName()).thenReturn("bryan@email.com");
-            when(userRepository.findByEmail("bryan@email.com"))
-                    .thenReturn(Optional.empty());
-
-            assertThatThrownBy(() -> userService.getMe(authentication))
-                    .isInstanceOf(EntityNotFoundException.class)
-                    .hasMessage("Authenticated user not found");
+            verify(authenticatedUserResolver).resolve(authentication);
         }
     }
 
     private void mockAuthenticatedUser(User user) {
-        when(authentication.getName()).thenReturn(user.getEmail());
-        when(userRepository.findByEmail(user.getEmail())).thenReturn(Optional.of(user));
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
     }
 
     private User buildUser() {


### PR DESCRIPTION
## Objetivo

Reduzir o acoplamento entre services do FinanceBot, melhorar a separação de responsabilidades e mover regras de negócio para componentes mais adequados.

## Alterações realizadas

- Criado `AuthenticatedUserResolver` para centralizar a resolução do usuário autenticado.
- Criado `UserResourceResolver` para centralizar a resolução de recursos pertencentes ao usuário, como contas e categorias.
- Criado `TransactionCategoryValidator` para centralizar a validação entre tipo da categoria e tipo da transação.
- Extraída a regra de parcelamento do `TransactionService` para o domínio de transações.
- Criados `InstallmentPlan`, `InstallmentPlanItem` e `InstallmentPlanFactory`.
- Reduzida a responsabilidade do `TransactionService`, deixando-o mais focado em orquestração.
- Ajustados testes dos services impactados.
- Adicionados testes para os novos componentes extraídos.
- Atualizado o `CHANGELOG.md` com a versão `1.1.4`.

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [x] Testes
- [x] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo claro
- [x] Executei `./mvnw test`
- [x] Os testes automatizados passaram
- [x] Novos testes foram adicionados quando houve mudança estrutural relevante
- [x] Não houve alteração funcional intencional na API
- [x] Regras de negócio foram movidas para componentes mais adequados
- [x] Atualizei o `CHANGELOG.md`

## Evidências

- Suíte de testes executada com sucesso.
- Testes adicionados para:
  - `AuthenticatedUserResolver`
  - `UserResourceResolver`
  - `TransactionCategoryValidator`
  - `InstallmentPlanFactory`
- Testes dos services ajustados após refatoração.

## Issue relacionada

Closes #35 