### PR TITLE
refatoração do caso de uso de transação do Telegram

### DIFF
--- a/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
+++ b/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
@@ -8,7 +8,10 @@ import com.financebot.category.domain.Category;
 import com.financebot.telegram.dto.request.*;
 import com.financebot.telegram.dto.response.*;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
+import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
+import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
+import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
@@ -42,6 +45,7 @@ public class TelegramIntegrationService {
     private final CreateInstallmentTransactionUseCase createInstallmentTransactionUseCase;
     private final TelegramAccountResolverService telegramAccountResolverService;
     private final TelegramCategoryResolverService telegramCategoryResolverService;
+    private final CreateTransactionUseCase createTransactionUseCase;
 
     @Transactional(readOnly = true)
     public TelegramUserProfileResponse getMe(Long telegramId) {
@@ -153,17 +157,17 @@ public class TelegramIntegrationService {
                 request.description()
         );
 
-        Transaction transaction = new Transaction();
-        transaction.setUser(user);
-        transaction.setAccount(account);
-        transaction.setCategory(category);
-        transaction.setAmount(request.amount());
-        transaction.setDescription(request.description());
-        transaction.setDate(request.date());
-        transaction.setType(transactionType);
-        transaction.setSourceType(SourceType.BOT_TEXT);
+        CreateTransactionRequest transactionRequest = new CreateTransactionRequest(
+                request.amount(),
+                request.description(),
+                request.date(),
+                transactionType,
+                SourceType.BOT_TEXT,
+                account.getId(),
+                category.getId()
+        );
 
-        transactionRepository.save(transaction);
+        createTransactionUseCase.executeForUser(transactionRequest, user);
     }
 
     @Transactional

--- a/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
+++ b/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
@@ -9,7 +9,6 @@ import com.financebot.telegram.dto.request.*;
 import com.financebot.telegram.dto.response.*;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
-import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;

--- a/src/main/java/com/financebot/transaction/application/usecase/CreateTransactionUseCase.java
+++ b/src/main/java/com/financebot/transaction/application/usecase/CreateTransactionUseCase.java
@@ -27,8 +27,27 @@ public class CreateTransactionUseCase {
     private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional
-    public TransactionResponse execute(CreateTransactionRequest request, Authentication authentication) {
+    public TransactionResponse execute(
+            CreateTransactionRequest request,
+            Authentication authentication
+    ) {
         User user = authenticatedUserResolver.resolve(authentication);
+
+        return createTransaction(request, user);
+    }
+
+    @Transactional
+    public TransactionResponse executeForUser(
+            CreateTransactionRequest request,
+            User user
+    ) {
+        return createTransaction(request, user);
+    }
+
+    private TransactionResponse createTransaction(
+            CreateTransactionRequest request,
+            User user
+    ) {
 
         Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
         Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());

--- a/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
+++ b/src/test/java/com/financebot/recurring/service/RecurringTransactionServiceTest.java
@@ -96,36 +96,14 @@ class RecurringTransactionServiceTest {
 
             RecurringTransactionResponse response = recurringTransactionService.create(request, authentication);
 
-            assertThat(response.id()).isEqualTo(RECURRING_TRANSACTION_ID);
-            assertThat(response.description()).isEqualTo("Aluguel");
-            assertThat(response.amount()).isEqualByComparingTo("1200.00");
-            assertThat(response.type()).isEqualTo(TransactionType.EXPENSE);
-            assertThat(response.sourceType()).isEqualTo(SourceType.WEB);
-            assertThat(response.frequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
-            assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 1));
-            assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 12, 1));
-            assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
-            assertThat(response.active()).isTrue();
-            assertThat(response.accountId()).isEqualTo(ACCOUNT_ID);
-            assertThat(response.categoryId()).isEqualTo(CATEGORY_ID);
+            assertCreatedRecurringTransactionResponse(response);
 
             ArgumentCaptor<RecurringTransaction> captor = ArgumentCaptor.forClass(RecurringTransaction.class);
             verify(recurringTransactionRepository).save(captor.capture());
 
             RecurringTransaction saved = captor.getValue();
 
-            assertThat(saved.getDescription()).isEqualTo("Aluguel");
-            assertThat(saved.getAmount()).isEqualByComparingTo("1200.00");
-            assertThat(saved.getType()).isEqualTo(TransactionType.EXPENSE);
-            assertThat(saved.getSourceType()).isEqualTo(SourceType.WEB);
-            assertThat(saved.getFrequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
-            assertThat(saved.getStartDate()).isEqualTo(LocalDate.of(2026, 4, 1));
-            assertThat(saved.getEndDate()).isEqualTo(LocalDate.of(2026, 12, 1));
-            assertThat(saved.getNextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
-            assertThat(saved.isActive()).isTrue();
-            assertThat(saved.getUser()).isEqualTo(user);
-            assertThat(saved.getAccount()).isEqualTo(account);
-            assertThat(saved.getCategory()).isEqualTo(category);
+            assertSavedRecurringTransaction(saved, user, account, category);
 
             verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         }
@@ -670,6 +648,41 @@ class RecurringTransactionServiceTest {
 
             assertThat(response.active()).isFalse();
         }
+    }
+
+    private void assertCreatedRecurringTransactionResponse(RecurringTransactionResponse response) {
+        assertThat(response.id()).isEqualTo(RECURRING_TRANSACTION_ID);
+        assertThat(response.description()).isEqualTo("Aluguel");
+        assertThat(response.amount()).isEqualByComparingTo("1200.00");
+        assertThat(response.type()).isEqualTo(TransactionType.EXPENSE);
+        assertThat(response.sourceType()).isEqualTo(SourceType.WEB);
+        assertThat(response.frequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
+        assertThat(response.startDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(response.endDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+        assertThat(response.nextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(response.active()).isTrue();
+        assertThat(response.accountId()).isEqualTo(ACCOUNT_ID);
+        assertThat(response.categoryId()).isEqualTo(CATEGORY_ID);
+    }
+
+    private void assertSavedRecurringTransaction(
+            RecurringTransaction saved,
+            User user,
+            Account account,
+            Category category
+    ) {
+        assertThat(saved.getDescription()).isEqualTo("Aluguel");
+        assertThat(saved.getAmount()).isEqualByComparingTo("1200.00");
+        assertThat(saved.getType()).isEqualTo(TransactionType.EXPENSE);
+        assertThat(saved.getSourceType()).isEqualTo(SourceType.WEB);
+        assertThat(saved.getFrequency()).isEqualTo(RecurrenceFrequency.MONTHLY);
+        assertThat(saved.getStartDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(saved.getEndDate()).isEqualTo(LocalDate.of(2026, 12, 1));
+        assertThat(saved.getNextExecutionDate()).isEqualTo(LocalDate.of(2026, 4, 1));
+        assertThat(saved.isActive()).isTrue();
+        assertThat(saved.getUser()).isEqualTo(user);
+        assertThat(saved.getAccount()).isEqualTo(account);
+        assertThat(saved.getCategory()).isEqualTo(category);
     }
 
     private void mockAuthenticatedUser(User user) {

--- a/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
+++ b/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
@@ -1,10 +1,17 @@
 package com.financebot.telegram.service;
 
+import com.financebot.account.domain.Account;
 import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.category.domain.Category;
+import com.financebot.telegram.dto.request.CreateTransactionFromTelegramRequest;
 import com.financebot.telegram.dto.request.InstallmentPurchaseCapacityRequest;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
+import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
+import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
+import com.financebot.transaction.domain.SourceType;
+import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
 import com.financebot.user.repository.UserRepository;
@@ -19,10 +26,15 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.time.LocalDate;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -42,6 +54,9 @@ class TelegramIntegrationServiceTest {
     private CreateInstallmentTransactionUseCase createInstallmentTransactionUseCase;
 
     @Mock
+    private CreateTransactionUseCase createTransactionUseCase;
+
+    @Mock
     private TelegramAccountResolverService telegramAccountResolverService;
 
     @Mock
@@ -49,6 +64,184 @@ class TelegramIntegrationServiceTest {
 
     @InjectMocks
     private TelegramIntegrationService telegramIntegrationService;
+
+    @Nested
+    @DisplayName("createTransactionFromTelegram")
+    class CreateTransactionFromTelegramTests {
+
+        @Test
+        @DisplayName("deve delegar criacao de transacao comum para o use case")
+        void shouldDelegateCommonTransactionCreationToUseCase() {
+            User user = new User();
+            user.setId(1L);
+            user.setTelegramId(123L);
+
+            Account account = new Account();
+            account.setId(10L);
+            account.setName("Carteira");
+
+            Category category = new Category();
+            category.setId(20L);
+            category.setName("Alimentação");
+
+            CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
+                    123L,
+                    "EXPENSE",
+                    new BigDecimal("50.00"),
+                    "lanche",
+                    LocalDate.of(2026, 5, 30),
+                    "Alimentação",
+                    "Carteira"
+            );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.of(user));
+            when(telegramAccountResolverService.resolve(user, "Carteira")).thenReturn(account);
+            when(telegramCategoryResolverService.resolveExplicitCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "Alimentação"
+            )).thenReturn(category);
+
+            telegramIntegrationService.createTransactionFromTelegram(request);
+
+            verify(createTransactionUseCase).executeForUser(
+                    argThat(transactionRequest ->
+                            transactionRequest.amount().compareTo(new BigDecimal("50.00")) == 0
+                                    && transactionRequest.description().equals("lanche")
+                                    && transactionRequest.date().equals(LocalDate.of(2026, 5, 30))
+                                    && transactionRequest.type() == TransactionType.EXPENSE
+                                    && transactionRequest.sourceType() == SourceType.BOT_TEXT
+                                    && transactionRequest.accountId().equals(10L)
+                                    && transactionRequest.categoryId().equals(20L)
+                    ),
+                    eq(user)
+            );
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve usar categoria automatica quando categoria nao for informada")
+        void shouldUseAutomaticCategoryWhenCategoryNameIsNotProvided() {
+            User user = new User();
+            user.setId(1L);
+            user.setTelegramId(123L);
+
+            Account account = new Account();
+            account.setId(10L);
+            account.setName("Carteira");
+
+            Category category = new Category();
+            category.setId(20L);
+            category.setName("Alimentação");
+
+            CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
+                    123L,
+                    "EXPENSE",
+                    new BigDecimal("50.00"),
+                    "lanche",
+                    LocalDate.of(2026, 5, 30),
+                    null,
+                    "Carteira"
+            );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.of(user));
+            when(telegramAccountResolverService.resolve(user, "Carteira")).thenReturn(account);
+            when(telegramCategoryResolverService.resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "lanche"
+            )).thenReturn(category);
+
+            telegramIntegrationService.createTransactionFromTelegram(request);
+
+            verify(telegramCategoryResolverService).resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "lanche"
+            );
+
+            verify(createTransactionUseCase).executeForUser(
+                    any(CreateTransactionRequest.class),
+                    eq(user)
+            );
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve usar categoria automatica quando categoria vier em branco")
+        void shouldUseAutomaticCategoryWhenCategoryNameIsBlank() {
+            User user = new User();
+            user.setId(1L);
+            user.setTelegramId(123L);
+
+            Account account = new Account();
+            account.setId(10L);
+            account.setName("Carteira");
+
+            Category category = new Category();
+            category.setId(20L);
+            category.setName("Alimentação");
+
+            CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
+                    123L,
+                    "EXPENSE",
+                    new BigDecimal("50.00"),
+                    "lanche",
+                    LocalDate.of(2026, 5, 30),
+                    "   ",
+                    "Carteira"
+            );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.of(user));
+            when(telegramAccountResolverService.resolve(user, "Carteira")).thenReturn(account);
+            when(telegramCategoryResolverService.resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "lanche"
+            )).thenReturn(category);
+
+            telegramIntegrationService.createTransactionFromTelegram(request);
+
+            verify(telegramCategoryResolverService).resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "lanche"
+            );
+
+            verify(createTransactionUseCase).executeForUser(
+                    any(CreateTransactionRequest.class),
+                    eq(user)
+            );
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando usuario do telegram nao existir")
+        void shouldThrowWhenTelegramUserDoesNotExistOnCreateTransaction() {
+            CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
+                    123L,
+                    "EXPENSE",
+                    new BigDecimal("50.00"),
+                    "lanche",
+                    LocalDate.of(2026, 5, 30),
+                    "Alimentação",
+                    "Carteira"
+            );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> telegramIntegrationService.createTransactionFromTelegram(request))
+                    .isInstanceOf(TelegramUserNotFoundException.class);
+
+            verify(createTransactionUseCase, never())
+                    .executeForUser(any(CreateTransactionRequest.class), any(User.class));
+
+            verify(transactionRepository, never()).save(any());
+        }
+    }
 
     @Nested
     @DisplayName("analyzeInstallmentPurchaseCapacity")

--- a/src/test/java/com/financebot/transaction/application/usecase/CreateTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/CreateTransactionUseCaseTest.java
@@ -83,14 +83,41 @@ class CreateTransactionUseCaseTest {
         TransactionResponse result = createTransactionUseCase.execute(request, authentication);
 
         assertThat(result).isEqualTo(response);
-        assertThat(transaction.getUser()).isEqualTo(user);
-        assertThat(transaction.getAccount()).isEqualTo(account);
-        assertThat(transaction.getCategory()).isEqualTo(category);
-        assertThat(transaction.getInstallment()).isFalse();
-        assertThat(transaction.getInstallmentNumber()).isNull();
-        assertThat(transaction.getTotalInstallments()).isNull();
-        assertThat(transaction.getInstallmentGroupId()).isNull();
+        assertTransactionLinkedToUserResources(transaction, user, account, category);
+        assertTransactionMarkedAsNonInstallment(transaction);
 
+        verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
+        verify(transactionMapper).toEntity(request);
+        verify(saveTransactionPort).save(transaction);
+        verify(transactionMapper).toResponse(savedTransaction);
+    }
+
+    @Test
+    @DisplayName("deve criar transação usando usuário já resolvido")
+    void shouldCreateTransactionForResolvedUser() {
+        User user = buildUser(1L, "bryan@email.com");
+        Account account = buildAccount(10L);
+        Category category = buildCategory(20L, CategoryType.EXPENSE);
+
+        CreateTransactionRequest request = buildCreateTransactionRequest();
+
+        Transaction transaction = new Transaction();
+        Transaction savedTransaction = new Transaction();
+        TransactionResponse response = mock(TransactionResponse.class);
+
+        when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
+        when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
+        when(transactionMapper.toEntity(request)).thenReturn(transaction);
+        when(saveTransactionPort.save(transaction)).thenReturn(savedTransaction);
+        when(transactionMapper.toResponse(savedTransaction)).thenReturn(response);
+
+        TransactionResponse result = createTransactionUseCase.executeForUser(request, user);
+
+        assertThat(result).isEqualTo(response);
+        assertTransactionLinkedToUserResources(transaction, user, account, category);
+        assertTransactionMarkedAsNonInstallment(transaction);
+
+        verifyNoInteractions(authenticatedUserResolver);
         verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
         verify(transactionMapper).toEntity(request);
         verify(saveTransactionPort).save(transaction);
@@ -155,6 +182,24 @@ class CreateTransactionUseCaseTest {
                 .hasMessage("Category type does not match transaction type");
 
         verifyNoInteractions(saveTransactionPort, transactionMapper);
+    }
+
+    private void assertTransactionLinkedToUserResources(
+            Transaction transaction,
+            User user,
+            Account account,
+            Category category
+    ) {
+        assertThat(transaction.getUser()).isEqualTo(user);
+        assertThat(transaction.getAccount()).isEqualTo(account);
+        assertThat(transaction.getCategory()).isEqualTo(category);
+    }
+
+    private void assertTransactionMarkedAsNonInstallment(Transaction transaction) {
+        assertThat(transaction.getInstallment()).isFalse();
+        assertThat(transaction.getInstallmentNumber()).isNull();
+        assertThat(transaction.getTotalInstallments()).isNull();
+        assertThat(transaction.getInstallmentGroupId()).isNull();
     }
 
     private CreateTransactionRequest buildCreateTransactionRequest() {

--- a/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
+++ b/src/test/java/com/financebot/transaction/domain/installment/InstallmentPlanFactoryTest.java
@@ -62,12 +62,18 @@ class InstallmentPlanFactoryTest {
         @Test
         @DisplayName("deve lancar erro quando tipo da transacao nao for despesa")
         void shouldThrowWhenTransactionTypeIsNotExpense() {
+            BigDecimal totalAmount = new BigDecimal("1000.00");
+            String description = "Salário parcelado";
+            LocalDate firstInstallmentDate = LocalDate.of(2026, 4, 10);
+            TransactionType transactionType = TransactionType.INCOME;
+            Integer totalInstallments = 3;
+
             assertThatThrownBy(() -> installmentPlanFactory.create(
-                    new BigDecimal("1000.00"),
-                    "Salário parcelado",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.INCOME,
-                    3
+                    totalAmount,
+                    description,
+                    firstInstallmentDate,
+                    transactionType,
+                    totalInstallments
             ))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Installment transactions are allowed only for expenses");
@@ -76,12 +82,18 @@ class InstallmentPlanFactoryTest {
         @Test
         @DisplayName("deve lancar erro quando total de parcelas for menor que dois")
         void shouldThrowWhenTotalInstallmentsIsLessThanTwo() {
+            BigDecimal totalAmount = new BigDecimal("1000.00");
+            String description = "Notebook";
+            LocalDate firstInstallmentDate = LocalDate.of(2026, 4, 10);
+            TransactionType transactionType = TransactionType.EXPENSE;
+            Integer totalInstallments = 1;
+
             assertThatThrownBy(() -> installmentPlanFactory.create(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    1
+                    totalAmount,
+                    description,
+                    firstInstallmentDate,
+                    transactionType,
+                    totalInstallments
             ))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");
@@ -90,12 +102,18 @@ class InstallmentPlanFactoryTest {
         @Test
         @DisplayName("deve lancar erro quando total de parcelas for nulo")
         void shouldThrowWhenTotalInstallmentsIsNull() {
+            BigDecimal totalAmount = new BigDecimal("1000.00");
+            String description = "Notebook";
+            LocalDate firstInstallmentDate = LocalDate.of(2026, 4, 10);
+            TransactionType transactionType = TransactionType.EXPENSE;
+            Integer totalInstallments = null;
+
             assertThatThrownBy(() -> installmentPlanFactory.create(
-                    new BigDecimal("1000.00"),
-                    "Notebook",
-                    LocalDate.of(2026, 4, 10),
-                    TransactionType.EXPENSE,
-                    null
+                    totalAmount,
+                    description,
+                    firstInstallmentDate,
+                    transactionType,
+                    totalInstallments
             ))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessage("Total installments must be at least 2");


### PR DESCRIPTION
## Objetivo

Promover para a branch `main` as alterações já integradas na `develop` relacionadas à refatoração do fluxo de criação de transações comuns via Telegram.

Este PR consolida a mudança que faz o `TelegramIntegrationService` reutilizar o `CreateTransactionUseCase`, evitando montagem e salvamento manual da entidade `Transaction` no fluxo de criação comum via Telegram.

## Alterações realizadas

- Refatorado o fluxo de criação de transações comuns via Telegram para reutilizar `CreateTransactionUseCase`.
- Adicionado método `executeForUser` no `CreateTransactionUseCase`, permitindo criar transações a partir de um `User` já resolvido.
- Removida a montagem manual da entidade `Transaction` no fluxo de criação comum dentro do `TelegramIntegrationService`.
- Mantido o fluxo de criação de transações parceladas usando `CreateInstallmentTransactionUseCase`.
- Atualizados testes unitários do `TelegramIntegrationService`.
- Adicionado teste direto para `CreateTransactionUseCase.executeForUser(...)`, garantindo que o método usa o `User` recebido e não depende de `Authentication`.
- Ajustados testes apontados pelo SonarQube para manter o Quality Gate limpo.
- Removido import não utilizado no `TelegramIntegrationService`.

## Trade-offs e decisões técnicas

- O `TransactionRepository` continua sendo usado no `TelegramIntegrationService` para consultas, resumos e análises financeiras já existentes. Este PR remove apenas o uso direto do repository para salvar transações comuns.
- O `CreateTransactionUseCase` ainda recebe `CreateTransactionRequest`, que atualmente está em `transaction.application.dto.request` e possui validações `jakarta.validation`. A separação entre DTOs HTTP e commands internos ficou fora do escopo deste PR e será tratada em issue própria.
- O `CreateTransactionUseCase` ainda mantém o método que recebe `Authentication`. A remoção dessa dependência dos use cases também será tratada em uma refatoração futura.
- O módulo Telegram não foi totalmente refatorado neste PR. O escopo ficou restrito ao fluxo de criação comum de transações.
- O fluxo de consultas e resumos do Telegram ainda acessa diretamente o `TransactionRepository`. Esse ponto foi mantido fora do escopo para evitar misturar refatoração de escrita com refatoração de leitura/relatórios.

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [x] Testes
- [ ] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [x] Executei `./mvnw clean verify`
- [x] Os testes automatizados passaram
- [x] Rodei análise local no SonarQube quando houve alteração relevante
- [x] O Quality Gate continua aprovado quando houve análise SonarQube
- [x] Não introduzi novas issues críticas de Security ou Reliability
- [x] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [ ] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- Testes automatizados executados com sucesso:
  - `158 tests`
  - `0 failures`
  - `0 errors`
  - `BUILD SUCCESS`

- SonarQube local executado após os ajustes:
  - `New issues`: 0
  - `Quality Gate`: Passed
  - `Security Hotspots`: 0

- Verificado que o módulo Telegram não cria/salva mais transações manualmente no fluxo comum:

```bash
grep -R "transactionRepository.save" -n src/main/java/com/financebot/telegram
grep -R "new Transaction()" -n src/main/java/com/financebot/telegram
```

## Testes realizados

- [x] `./mvnw clean verify`
- [x] Testes unitários específicos
- [ ] Teste manual
- [x] Análise SonarQube local
- [ ] Não se aplica

## Issue relacionada

Closes #66

## Observação

Este PR consolida mudanças já revisadas e integradas previamente na branch `develop`.