### PR TITLE
Refatora use cases de transações para usar commands internos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@
 - Separados DTOs de request HTTP dos commands internos nos fluxos de criação, criação parcelada e atualização de transações.
 - Ajustado o fluxo de parcelamento para `CreateInstallmentTransactionUseCase` receber `CreateInstallmentTransactionCommand`.
 - Ajustado o fluxo de atualização para `UpdateTransactionUseCase` receber `UpdateTransactionCommand`.
-- Ajustado o fluxo do Telegram para criar transações parceladas usando command interno em vez de DTO HTTP.
+- Ajustado o fluxo do Telegram para criar transações comuns e parceladas usando commands internos em vez de DTOs HTTP.
 
 ### Added
 - Adicionados ports de saída para persistência de transações.
 - Adicionado `TransactionPersistenceAdapter`.
+
+### Tests
 - Adicionados testes unitários para use cases, controller e adapter de persistência de transações.
 - Atualizados testes de use cases, controller e integração Telegram para os novos commands internos.
-
+- Adicionada cobertura para criação parcelada via Telegram delegando para `CreateInstallmentTransactionCommand`.
+- 
 ## v1.2.0
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,16 @@
 - Removido o `TransactionService`, substituindo o fluxo por use cases e ports/adapters.
 - Movido `TransactionController` para `adapter/in/web`.
 - Isolado o acesso a `TransactionRepository` e `TransactionSpecification` no adapter de persistência.
+- Separados DTOs de request HTTP dos commands internos nos fluxos de criação, criação parcelada e atualização de transações.
+- Ajustado o fluxo de parcelamento para `CreateInstallmentTransactionUseCase` receber `CreateInstallmentTransactionCommand`.
+- Ajustado o fluxo de atualização para `UpdateTransactionUseCase` receber `UpdateTransactionCommand`.
+- Ajustado o fluxo do Telegram para criar transações parceladas usando command interno em vez de DTO HTTP.
 
 ### Added
 - Adicionados ports de saída para persistência de transações.
 - Adicionado `TransactionPersistenceAdapter`.
 - Adicionados testes unitários para use cases, controller e adapter de persistência de transações.
+- Atualizados testes de use cases, controller e integração Telegram para os novos commands internos.
 
 ## v1.2.0
 

--- a/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
+++ b/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
@@ -8,14 +8,13 @@ import com.financebot.category.domain.Category;
 import com.financebot.telegram.dto.request.*;
 import com.financebot.telegram.dto.response.*;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
-import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
-import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.user.domain.User;
 import com.financebot.user.dto.request.UpdateMonthlyBaseIncomeRequest;
@@ -183,7 +182,7 @@ public class TelegramIntegrationService {
                 request.description()
         );
 
-        CreateInstallmentTransactionRequest installmentRequest = new CreateInstallmentTransactionRequest(
+        CreateInstallmentTransactionCommand command = new CreateInstallmentTransactionCommand(
                 request.totalAmount(),
                 request.description(),
                 request.firstInstallmentDate(),
@@ -191,10 +190,11 @@ public class TelegramIntegrationService {
                 SourceType.BOT_TEXT,
                 account.getId(),
                 category.getId(),
-                request.totalInstallments()
+                request.totalInstallments(),
+                user
         );
 
-        createInstallmentTransactionUseCase.executeForUser(installmentRequest, user);
+        createInstallmentTransactionUseCase.execute(command);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
+++ b/src/main/java/com/financebot/telegram/service/TelegramIntegrationService.java
@@ -8,6 +8,7 @@ import com.financebot.category.domain.Category;
 import com.financebot.telegram.dto.request.*;
 import com.financebot.telegram.dto.response.*;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
@@ -156,17 +157,18 @@ public class TelegramIntegrationService {
                 request.description()
         );
 
-        CreateTransactionRequest transactionRequest = new CreateTransactionRequest(
+        CreateTransactionCommand command = new CreateTransactionCommand(
                 request.amount(),
                 request.description(),
                 request.date(),
                 transactionType,
                 SourceType.BOT_TEXT,
                 account.getId(),
-                category.getId()
+                category.getId(),
+                user
         );
 
-        createTransactionUseCase.executeForUser(transactionRequest, user);
+        createTransactionUseCase.execute(command);
     }
 
     @Transactional

--- a/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
@@ -4,6 +4,7 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
@@ -70,8 +71,11 @@ public class TransactionController {
             @RequestBody @Valid CreateInstallmentTransactionRequest request,
             Authentication authentication
     ) {
+        User user = authenticatedUserResolver.resolve(authentication);
+        CreateInstallmentTransactionCommand command = transactionMapper.toCommand(request, user);
+
         InstallmentTransactionResponse installment =
-                createInstallmentTransactionUseCase.execute(request, authentication);
+                createInstallmentTransactionUseCase.execute(command);
 
         FinancialCommitmentResponse analysis = financialAnalysisService.getFinancialCommitment(authentication);
 

--- a/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
@@ -6,6 +6,7 @@ import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
 import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
+import com.financebot.transaction.application.command.UpdateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
@@ -125,7 +126,10 @@ public class TransactionController {
             @RequestBody @Valid UpdateTransactionRequest request,
             Authentication authentication
     ) {
-        return updateTransactionUseCase.execute(id, request, authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
+        UpdateTransactionCommand command = transactionMapper.toCommand(id, request, user);
+
+        return updateTransactionUseCase.execute(command);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
@@ -4,6 +4,12 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
+import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
+import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
+import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
+import com.financebot.transaction.application.dto.response.InstallmentTransactionResponse;
+import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
 import com.financebot.transaction.application.usecase.DeleteTransactionUseCase;
@@ -12,12 +18,10 @@ import com.financebot.transaction.application.usecase.ListTransactionsUseCase;
 import com.financebot.transaction.application.usecase.UpdateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.TransactionType;
-import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
-import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
-import com.financebot.transaction.application.dto.response.InstallmentTransactionResponse;
 import com.financebot.transaction.dto.TransactionFilter;
-import com.financebot.transaction.application.dto.response.TransactionResponse;
-import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
+import com.financebot.transaction.mapper.TransactionMapper;
+import com.financebot.user.domain.User;
+import com.financebot.user.service.AuthenticatedUserResolver;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -33,7 +37,10 @@ import java.time.LocalDate;
 @RequestMapping("/transactions")
 @RequiredArgsConstructor
 public class TransactionController {
+
     private final FinancialAnalysisService financialAnalysisService;
+    private final AuthenticatedUserResolver authenticatedUserResolver;
+    private final TransactionMapper transactionMapper;
 
     private final CreateTransactionUseCase createTransactionUseCase;
     private final CreateInstallmentTransactionUseCase createInstallmentTransactionUseCase;
@@ -48,7 +55,10 @@ public class TransactionController {
             @RequestBody @Valid CreateTransactionRequest request,
             Authentication authentication
     ) {
-        TransactionResponse transaction = createTransactionUseCase.execute(request, authentication);
+        User user = authenticatedUserResolver.resolve(authentication);
+        CreateTransactionCommand command = transactionMapper.toCommand(request, user);
+
+        TransactionResponse transaction = createTransactionUseCase.execute(command);
         FinancialCommitmentResponse analysis = financialAnalysisService.getFinancialCommitment(authentication);
 
         return new TransactionCreationResponse(transaction, analysis);

--- a/src/main/java/com/financebot/transaction/application/command/CreateInstallmentTransactionCommand.java
+++ b/src/main/java/com/financebot/transaction/application/command/CreateInstallmentTransactionCommand.java
@@ -1,0 +1,21 @@
+package com.financebot.transaction.application.command;
+
+import com.financebot.transaction.domain.SourceType;
+import com.financebot.transaction.domain.TransactionType;
+import com.financebot.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CreateInstallmentTransactionCommand(
+        BigDecimal totalAmount,
+        String description,
+        LocalDate firstInstallmentDate,
+        TransactionType type,
+        SourceType sourceType,
+        Long accountId,
+        Long categoryId,
+        Integer totalInstallments,
+        User user
+) {
+}

--- a/src/main/java/com/financebot/transaction/application/command/CreateTransactionCommand.java
+++ b/src/main/java/com/financebot/transaction/application/command/CreateTransactionCommand.java
@@ -1,0 +1,20 @@
+package com.financebot.transaction.application.command;
+
+import com.financebot.transaction.domain.SourceType;
+import com.financebot.transaction.domain.TransactionType;
+import com.financebot.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record CreateTransactionCommand(
+        BigDecimal amount,
+        String description,
+        LocalDate date,
+        TransactionType type,
+        SourceType sourceType,
+        Long accountId,
+        Long categoryId,
+        User user
+) {
+}

--- a/src/main/java/com/financebot/transaction/application/command/UpdateTransactionCommand.java
+++ b/src/main/java/com/financebot/transaction/application/command/UpdateTransactionCommand.java
@@ -1,0 +1,21 @@
+package com.financebot.transaction.application.command;
+
+import com.financebot.transaction.domain.SourceType;
+import com.financebot.transaction.domain.TransactionType;
+import com.financebot.user.domain.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record UpdateTransactionCommand(
+        Long transactionId,
+        BigDecimal amount,
+        String description,
+        LocalDate date,
+        TransactionType type,
+        SourceType sourceType,
+        Long accountId,
+        Long categoryId,
+        User user
+) {
+}

--- a/src/main/java/com/financebot/transaction/application/usecase/CreateInstallmentTransactionUseCase.java
+++ b/src/main/java/com/financebot/transaction/application/usecase/CreateInstallmentTransactionUseCase.java
@@ -2,7 +2,7 @@ package com.financebot.transaction.application.usecase;
 
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
-import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.dto.response.InstallmentTransactionResponse;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
@@ -12,11 +12,8 @@ import com.financebot.transaction.domain.installment.InstallmentPlanFactory;
 import com.financebot.transaction.domain.installment.InstallmentPlanItem;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
-import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,50 +26,28 @@ public class CreateInstallmentTransactionUseCase {
     private final SaveTransactionPort saveTransactionPort;
     private final UserResourceResolver userResourceResolver;
     private final TransactionMapper transactionMapper;
-    private final AuthenticatedUserResolver authenticatedUserResolver;
     private final TransactionCategoryValidator transactionCategoryValidator;
     private final InstallmentPlanFactory installmentPlanFactory;
 
     @Transactional
-    public InstallmentTransactionResponse execute(
-            CreateInstallmentTransactionRequest request,
-            Authentication authentication
-    ) {
-        User user = authenticatedUserResolver.resolve(authentication);
-
-        return createInstallment(request, user);
-    }
-
-    @Transactional
-    public InstallmentTransactionResponse executeForUser(
-            CreateInstallmentTransactionRequest request,
-            User user
-    ) {
-        return createInstallment(request, user);
-    }
-
-    private InstallmentTransactionResponse createInstallment(
-            CreateInstallmentTransactionRequest request,
-            User user
-    ) {
+    public InstallmentTransactionResponse execute(CreateInstallmentTransactionCommand command) {
         InstallmentPlan plan = installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         );
 
-        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
-        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(command.accountId(), command.user().getId());
+        Category category = userResourceResolver.resolveCategory(command.categoryId(), command.user().getId());
 
-        transactionCategoryValidator.validate(category, request.type());
+        transactionCategoryValidator.validate(category, command.type());
 
         List<Transaction> transactions = plan.items().stream()
                 .map(item -> buildInstallmentTransaction(
                         item,
-                        request,
-                        user,
+                        command,
                         account,
                         category
                 ))
@@ -93,8 +68,7 @@ public class CreateInstallmentTransactionUseCase {
 
     private Transaction buildInstallmentTransaction(
             InstallmentPlanItem item,
-            CreateInstallmentTransactionRequest request,
-            User user,
+            CreateInstallmentTransactionCommand command,
             Account account,
             Category category
     ) {
@@ -103,9 +77,9 @@ public class CreateInstallmentTransactionUseCase {
         transaction.setAmount(item.amount());
         transaction.setDescription(item.description());
         transaction.setDate(item.date());
-        transaction.setType(request.type());
-        transaction.setSourceType(request.sourceType());
-        transaction.setUser(user);
+        transaction.setType(command.type());
+        transaction.setSourceType(command.sourceType());
+        transaction.setUser(command.user());
         transaction.setAccount(account);
         transaction.setCategory(category);
         transaction.setInstallment(true);

--- a/src/main/java/com/financebot/transaction/application/usecase/CreateTransactionUseCase.java
+++ b/src/main/java/com/financebot/transaction/application/usecase/CreateTransactionUseCase.java
@@ -2,17 +2,14 @@ package com.financebot.transaction.application.usecase;
 
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
-import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
-import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,39 +20,24 @@ public class CreateTransactionUseCase {
     private final SaveTransactionPort saveTransactionPort;
     private final UserResourceResolver userResourceResolver;
     private final TransactionMapper transactionMapper;
-    private final AuthenticatedUserResolver authenticatedUserResolver;
     private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional
-    public TransactionResponse execute(
-            CreateTransactionRequest request,
-            Authentication authentication
-    ) {
-        User user = authenticatedUserResolver.resolve(authentication);
+    public TransactionResponse execute(CreateTransactionCommand command) {
+        Account account = userResourceResolver.resolveAccount(
+                command.accountId(),
+                command.user().getId()
+        );
 
-        return createTransaction(request, user);
-    }
+        Category category = userResourceResolver.resolveCategory(
+                command.categoryId(),
+                command.user().getId()
+        );
 
-    @Transactional
-    public TransactionResponse executeForUser(
-            CreateTransactionRequest request,
-            User user
-    ) {
-        return createTransaction(request, user);
-    }
+        transactionCategoryValidator.validate(category, command.type());
 
-    private TransactionResponse createTransaction(
-            CreateTransactionRequest request,
-            User user
-    ) {
-
-        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
-        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
-
-        transactionCategoryValidator.validate(category, request.type());
-
-        Transaction transaction = transactionMapper.toEntity(request);
-        transaction.setUser(user);
+        Transaction transaction = transactionMapper.toEntity(command);
+        transaction.setUser(command.user());
         transaction.setAccount(account);
         transaction.setCategory(category);
         transaction.setInstallment(false);

--- a/src/main/java/com/financebot/transaction/application/usecase/UpdateTransactionUseCase.java
+++ b/src/main/java/com/financebot/transaction/application/usecase/UpdateTransactionUseCase.java
@@ -2,19 +2,16 @@ package com.financebot.transaction.application.usecase;
 
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
-import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
+import com.financebot.transaction.application.command.UpdateTransactionCommand;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
-import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,26 +25,29 @@ public class UpdateTransactionUseCase {
     private final SaveTransactionPort saveTransactionPort;
     private final UserResourceResolver userResourceResolver;
     private final TransactionMapper transactionMapper;
-    private final AuthenticatedUserResolver authenticatedUserResolver;
     private final TransactionCategoryValidator transactionCategoryValidator;
 
     @Transactional
-    public TransactionResponse execute(
-            Long id,
-            UpdateTransactionRequest request,
-            Authentication authentication
-    ) {
-        User user = authenticatedUserResolver.resolve(authentication);
-
-        Transaction transaction = findTransactionPort.findByIdAndUserId(id, user.getId())
+    public TransactionResponse execute(UpdateTransactionCommand command) {
+        Transaction transaction = findTransactionPort.findByIdAndUserId(
+                        command.transactionId(),
+                        command.user().getId()
+                )
                 .orElseThrow(() -> new EntityNotFoundException(TRANSACTION_NOT_FOUND_MESSAGE));
 
-        Account account = userResourceResolver.resolveAccount(request.accountId(), user.getId());
-        Category category = userResourceResolver.resolveCategory(request.categoryId(), user.getId());
+        Account account = userResourceResolver.resolveAccount(
+                command.accountId(),
+                command.user().getId()
+        );
 
-        transactionCategoryValidator.validate(category, request.type());
+        Category category = userResourceResolver.resolveCategory(
+                command.categoryId(),
+                command.user().getId()
+        );
 
-        transactionMapper.updateEntity(request, transaction);
+        transactionCategoryValidator.validate(category, command.type());
+
+        transactionMapper.updateEntity(command, transaction);
         transaction.setAccount(account);
         transaction.setCategory(category);
 

--- a/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
@@ -1,12 +1,12 @@
 package com.financebot.transaction.mapper;
 
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.command.UpdateTransactionCommand;
+import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
-import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
-import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.user.domain.User;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
@@ -1,6 +1,7 @@
 package com.financebot.transaction.mapper;
 
 import com.financebot.transaction.application.command.CreateTransactionCommand;
+import com.financebot.transaction.application.command.UpdateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
@@ -53,12 +54,30 @@ public class TransactionMapper {
         );
     }
 
-    public void updateEntity(UpdateTransactionRequest dto, Transaction transaction) {
-        transaction.setAmount(dto.amount());
-        transaction.setDescription(dto.description().trim());
-        transaction.setDate(dto.date());
-        transaction.setType(dto.type());
-        transaction.setSourceType(dto.sourceType());
+    public UpdateTransactionCommand toCommand(
+            Long transactionId,
+            UpdateTransactionRequest request,
+            User user
+    ) {
+        return new UpdateTransactionCommand(
+                transactionId,
+                request.amount(),
+                request.description(),
+                request.date(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                user
+        );
+    }
+
+    public void updateEntity(UpdateTransactionCommand command, Transaction transaction) {
+        transaction.setAmount(command.amount());
+        transaction.setDescription(command.description().trim());
+        transaction.setDate(command.date());
+        transaction.setType(command.type());
+        transaction.setSourceType(command.sourceType());
     }
 
     public TransactionResponse toResponse(Transaction transaction) {

--- a/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
@@ -4,6 +4,8 @@ import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
+import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.user.domain.User;
 import org.springframework.stereotype.Component;
@@ -34,14 +36,21 @@ public class TransactionMapper {
         return transaction;
     }
 
-    public Transaction toEntity(CreateTransactionRequest dto) {
-        Transaction transaction = new Transaction();
-        transaction.setAmount(dto.amount());
-        transaction.setDescription(dto.description().trim());
-        transaction.setDate(dto.date());
-        transaction.setType(dto.type());
-        transaction.setSourceType(dto.sourceType());
-        return transaction;
+    public CreateInstallmentTransactionCommand toCommand(
+            CreateInstallmentTransactionRequest request,
+            User user
+    ) {
+        return new CreateInstallmentTransactionCommand(
+                request.totalAmount(),
+                request.description(),
+                request.firstInstallmentDate(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                request.totalInstallments(),
+                user
+        );
     }
 
     public void updateEntity(UpdateTransactionRequest dto, Transaction transaction) {

--- a/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
+++ b/src/main/java/com/financebot/transaction/mapper/TransactionMapper.java
@@ -1,13 +1,38 @@
 package com.financebot.transaction.mapper;
 
-import com.financebot.transaction.domain.Transaction;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
-import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
+import com.financebot.transaction.application.dto.response.TransactionResponse;
+import com.financebot.transaction.domain.Transaction;
+import com.financebot.user.domain.User;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TransactionMapper {
+
+    public CreateTransactionCommand toCommand(CreateTransactionRequest request, User user) {
+        return new CreateTransactionCommand(
+                request.amount(),
+                request.description(),
+                request.date(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                user
+        );
+    }
+
+    public Transaction toEntity(CreateTransactionCommand command) {
+        Transaction transaction = new Transaction();
+        transaction.setAmount(command.amount());
+        transaction.setDescription(command.description().trim());
+        transaction.setDate(command.date());
+        transaction.setType(command.type());
+        transaction.setSourceType(command.sourceType());
+        return transaction;
+    }
 
     public Transaction toEntity(CreateTransactionRequest dto) {
         Transaction transaction = new Transaction();

--- a/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
+++ b/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
@@ -4,9 +4,11 @@ import com.financebot.account.domain.Account;
 import com.financebot.analysis.dto.response.InstallmentPurchaseCapacityResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
 import com.financebot.category.domain.Category;
+import com.financebot.telegram.dto.request.CreateInstallmentTransactionFromTelegramRequest;
 import com.financebot.telegram.dto.request.CreateTransactionFromTelegramRequest;
 import com.financebot.telegram.dto.request.InstallmentPurchaseCapacityRequest;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
@@ -71,17 +73,9 @@ class TelegramIntegrationServiceTest {
         @Test
         @DisplayName("deve delegar criacao de transacao comum para o use case")
         void shouldDelegateCommonTransactionCreationToUseCase() {
-            User user = new User();
-            user.setId(1L);
-            user.setTelegramId(123L);
-
-            Account account = new Account();
-            account.setId(10L);
-            account.setName("Carteira");
-
-            Category category = new Category();
-            category.setId(20L);
-            category.setName("Alimentação");
+            User user = buildTelegramUser();
+            Account account = buildAccount();
+            Category category = buildCategory("Alimentação");
 
             CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
                     123L,
@@ -122,17 +116,9 @@ class TelegramIntegrationServiceTest {
         @Test
         @DisplayName("deve usar categoria automatica quando categoria nao for informada")
         void shouldUseAutomaticCategoryWhenCategoryNameIsNotProvided() {
-            User user = new User();
-            user.setId(1L);
-            user.setTelegramId(123L);
-
-            Account account = new Account();
-            account.setId(10L);
-            account.setName("Carteira");
-
-            Category category = new Category();
-            category.setId(20L);
-            category.setName("Alimentação");
+            User user = buildTelegramUser();
+            Account account = buildAccount();
+            Category category = buildCategory("Alimentação");
 
             CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
                     123L,
@@ -170,17 +156,9 @@ class TelegramIntegrationServiceTest {
         @Test
         @DisplayName("deve usar categoria automatica quando categoria vier em branco")
         void shouldUseAutomaticCategoryWhenCategoryNameIsBlank() {
-            User user = new User();
-            user.setId(1L);
-            user.setTelegramId(123L);
-
-            Account account = new Account();
-            account.setId(10L);
-            account.setName("Carteira");
-
-            Category category = new Category();
-            category.setId(20L);
-            category.setName("Alimentação");
+            User user = buildTelegramUser();
+            Account account = buildAccount();
+            Category category = buildCategory("Alimentação");
 
             CreateTransactionFromTelegramRequest request = new CreateTransactionFromTelegramRequest(
                     123L,
@@ -241,15 +219,129 @@ class TelegramIntegrationServiceTest {
     }
 
     @Nested
+    @DisplayName("createInstallmentTransactionFromTelegram")
+    class CreateInstallmentTransactionFromTelegramTests {
+
+        @Test
+        @DisplayName("deve delegar criacao de transacao parcelada para o use case")
+        void shouldDelegateInstallmentTransactionCreationToUseCase() {
+            User user = buildTelegramUser();
+            Account account = buildAccount();
+            Category category = buildCategory("Eletrônicos");
+
+            CreateInstallmentTransactionFromTelegramRequest request =
+                    new CreateInstallmentTransactionFromTelegramRequest(
+                            123L,
+                            new BigDecimal("1200.00"),
+                            "Notebook",
+                            LocalDate.of(2026, 6, 1),
+                            "Carteira",
+                            "Eletrônicos",
+                            12
+                    );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.of(user));
+            when(telegramAccountResolverService.resolve(user, "Carteira")).thenReturn(account);
+            when(telegramCategoryResolverService.resolveExplicitCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "Eletrônicos"
+            )).thenReturn(category);
+
+            telegramIntegrationService.createInstallmentTransactionFromTelegram(request);
+
+            verify(createInstallmentTransactionUseCase).execute(
+                    argThat(command ->
+                            command.totalAmount().compareTo(new BigDecimal("1200.00")) == 0
+                                    && command.description().equals("Notebook")
+                                    && command.firstInstallmentDate().equals(LocalDate.of(2026, 6, 1))
+                                    && command.type() == TransactionType.EXPENSE
+                                    && command.sourceType() == SourceType.BOT_TEXT
+                                    && command.accountId().equals(10L)
+                                    && command.categoryId().equals(20L)
+                                    && command.totalInstallments().equals(12)
+                                    && command.user().equals(user)
+                    )
+            );
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve usar categoria automatica no parcelamento quando categoria nao for informada")
+        void shouldUseAutomaticCategoryForInstallmentWhenCategoryNameIsNotProvided() {
+            User user = buildTelegramUser();
+            Account account = buildAccount();
+            Category category = buildCategory("Eletrônicos");
+
+            CreateInstallmentTransactionFromTelegramRequest request =
+                    new CreateInstallmentTransactionFromTelegramRequest(
+                            123L,
+                            new BigDecimal("1200.00"),
+                            "Notebook",
+                            LocalDate.of(2026, 6, 1),
+                            "Carteira",
+                            null,
+                            12
+                    );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.of(user));
+            when(telegramAccountResolverService.resolve(user, "Carteira")).thenReturn(account);
+            when(telegramCategoryResolverService.resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "Notebook"
+            )).thenReturn(category);
+
+            telegramIntegrationService.createInstallmentTransactionFromTelegram(request);
+
+            verify(telegramCategoryResolverService).resolveCategory(
+                    user,
+                    TransactionType.EXPENSE,
+                    "Notebook"
+            );
+
+            verify(createInstallmentTransactionUseCase).execute(
+                    any(CreateInstallmentTransactionCommand.class)
+            );
+
+            verify(transactionRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("deve lancar erro quando usuario do telegram nao existir no parcelamento")
+        void shouldThrowWhenTelegramUserDoesNotExistOnCreateInstallmentTransaction() {
+            CreateInstallmentTransactionFromTelegramRequest request =
+                    new CreateInstallmentTransactionFromTelegramRequest(
+                            123L,
+                            new BigDecimal("1200.00"),
+                            "Notebook",
+                            LocalDate.of(2026, 6, 1),
+                            "Carteira",
+                            "Eletrônicos",
+                            12
+                    );
+
+            when(userRepository.findByTelegramId(123L)).thenReturn(Optional.empty());
+
+            assertThatThrownBy(() -> telegramIntegrationService.createInstallmentTransactionFromTelegram(request))
+                    .isInstanceOf(TelegramUserNotFoundException.class);
+
+            verify(createInstallmentTransactionUseCase, never())
+                    .execute(any(CreateInstallmentTransactionCommand.class));
+
+            verify(transactionRepository, never()).save(any());
+        }
+    }
+
+    @Nested
     @DisplayName("analyzeInstallmentPurchaseCapacity")
     class AnalyzeInstallmentPurchaseCapacityTests {
 
         @Test
         @DisplayName("deve delegar analise de compra parcelada para o financial analysis service")
         void shouldDelegateInstallmentPurchaseCapacityAnalysis() {
-            User user = new User();
-            user.setId(1L);
-            user.setTelegramId(123L);
+            User user = buildTelegramUser();
 
             InstallmentPurchaseCapacityRequest request = new InstallmentPurchaseCapacityRequest(
                     123L,
@@ -398,5 +490,26 @@ class TelegramIntegrationServiceTest {
 
             return (String) method.invoke(telegramIntegrationService, description);
         }
+    }
+
+    private User buildTelegramUser() {
+        User user = new User();
+        user.setId(1L);
+        user.setTelegramId(123L);
+        return user;
+    }
+
+    private Account buildAccount() {
+        Account account = new Account();
+        account.setId(10L);
+        account.setName("Carteira");
+        return account;
+    }
+
+    private Category buildCategory(String name) {
+        Category category = new Category();
+        category.setId(20L);
+        category.setName(name);
+        return category;
     }
 }

--- a/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
+++ b/src/test/java/com/financebot/telegram/service/TelegramIntegrationServiceTest.java
@@ -7,7 +7,7 @@ import com.financebot.category.domain.Category;
 import com.financebot.telegram.dto.request.CreateTransactionFromTelegramRequest;
 import com.financebot.telegram.dto.request.InstallmentPurchaseCapacityRequest;
 import com.financebot.telegram.exception.TelegramUserNotFoundException;
-import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.usecase.CreateInstallmentTransactionUseCase;
 import com.financebot.transaction.application.usecase.CreateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;
@@ -33,7 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -104,17 +103,17 @@ class TelegramIntegrationServiceTest {
 
             telegramIntegrationService.createTransactionFromTelegram(request);
 
-            verify(createTransactionUseCase).executeForUser(
-                    argThat(transactionRequest ->
-                            transactionRequest.amount().compareTo(new BigDecimal("50.00")) == 0
-                                    && transactionRequest.description().equals("lanche")
-                                    && transactionRequest.date().equals(LocalDate.of(2026, 5, 30))
-                                    && transactionRequest.type() == TransactionType.EXPENSE
-                                    && transactionRequest.sourceType() == SourceType.BOT_TEXT
-                                    && transactionRequest.accountId().equals(10L)
-                                    && transactionRequest.categoryId().equals(20L)
-                    ),
-                    eq(user)
+            verify(createTransactionUseCase).execute(
+                    argThat(command ->
+                            command.amount().compareTo(new BigDecimal("50.00")) == 0
+                                    && command.description().equals("lanche")
+                                    && command.date().equals(LocalDate.of(2026, 5, 30))
+                                    && command.type() == TransactionType.EXPENSE
+                                    && command.sourceType() == SourceType.BOT_TEXT
+                                    && command.accountId().equals(10L)
+                                    && command.categoryId().equals(20L)
+                                    && command.user().equals(user)
+                    )
             );
 
             verify(transactionRepository, never()).save(any());
@@ -161,9 +160,8 @@ class TelegramIntegrationServiceTest {
                     "lanche"
             );
 
-            verify(createTransactionUseCase).executeForUser(
-                    any(CreateTransactionRequest.class),
-                    eq(user)
+            verify(createTransactionUseCase).execute(
+                    any(CreateTransactionCommand.class)
             );
 
             verify(transactionRepository, never()).save(any());
@@ -210,9 +208,8 @@ class TelegramIntegrationServiceTest {
                     "lanche"
             );
 
-            verify(createTransactionUseCase).executeForUser(
-                    any(CreateTransactionRequest.class),
-                    eq(user)
+            verify(createTransactionUseCase).execute(
+                    any(CreateTransactionCommand.class)
             );
 
             verify(transactionRepository, never()).save(any());
@@ -237,7 +234,7 @@ class TelegramIntegrationServiceTest {
                     .isInstanceOf(TelegramUserNotFoundException.class);
 
             verify(createTransactionUseCase, never())
-                    .executeForUser(any(CreateTransactionRequest.class), any(User.class));
+                    .execute(any(CreateTransactionCommand.class));
 
             verify(transactionRepository, never()).save(any());
         }

--- a/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
@@ -6,6 +6,7 @@ import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
 import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
+import com.financebot.transaction.application.command.UpdateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
@@ -250,15 +251,34 @@ class TransactionControllerTest {
                 20L
         );
 
+        User user = new User();
+        user.setId(1L);
+
+        UpdateTransactionCommand command = new UpdateTransactionCommand(
+                77L,
+                request.amount(),
+                request.description(),
+                request.date(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                user
+        );
+
         TransactionResponse response = mock(TransactionResponse.class);
 
-        when(updateTransactionUseCase.execute(77L, request, authentication)).thenReturn(response);
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
+        when(transactionMapper.toCommand(77L, request, user)).thenReturn(command);
+        when(updateTransactionUseCase.execute(command)).thenReturn(response);
 
         TransactionResponse result = transactionController.update(77L, request, authentication);
 
         assertThat(result).isEqualTo(response);
 
-        verify(updateTransactionUseCase).execute(77L, request, authentication);
+        verify(authenticatedUserResolver).resolve(authentication);
+        verify(transactionMapper).toCommand(77L, request, user);
+        verify(updateTransactionUseCase).execute(command);
     }
 
     @Test

--- a/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
@@ -4,6 +4,7 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
@@ -140,10 +141,27 @@ class TransactionControllerTest {
                 3
         );
 
+        User user = new User();
+        user.setId(1L);
+
+        CreateInstallmentTransactionCommand command = new CreateInstallmentTransactionCommand(
+                request.totalAmount(),
+                request.description(),
+                request.firstInstallmentDate(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                request.totalInstallments(),
+                user
+        );
+
         InstallmentTransactionResponse installmentResponse = mock(InstallmentTransactionResponse.class);
         FinancialCommitmentResponse financialAnalysis = mock(FinancialCommitmentResponse.class);
 
-        when(createInstallmentTransactionUseCase.execute(request, authentication)).thenReturn(installmentResponse);
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
+        when(transactionMapper.toCommand(request, user)).thenReturn(command);
+        when(createInstallmentTransactionUseCase.execute(command)).thenReturn(installmentResponse);
         when(financialAnalysisService.getFinancialCommitment(authentication)).thenReturn(financialAnalysis);
 
         InstallmentTransactionCreationResponse result =
@@ -152,7 +170,9 @@ class TransactionControllerTest {
         assertThat(result.installment()).isEqualTo(installmentResponse);
         assertThat(result.analysis()).isEqualTo(financialAnalysis);
 
-        verify(createInstallmentTransactionUseCase).execute(request, authentication);
+        verify(authenticatedUserResolver).resolve(authentication);
+        verify(transactionMapper).toCommand(request, user);
+        verify(createInstallmentTransactionUseCase).execute(command);
         verify(financialAnalysisService).getFinancialCommitment(authentication);
     }
 

--- a/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
@@ -4,6 +4,7 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
 import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
 import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
@@ -18,6 +19,9 @@ import com.financebot.transaction.application.usecase.UpdateTransactionUseCase;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.dto.TransactionFilter;
+import com.financebot.transaction.mapper.TransactionMapper;
+import com.financebot.user.domain.User;
+import com.financebot.user.service.AuthenticatedUserResolver;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +49,12 @@ class TransactionControllerTest {
 
     @Mock
     private FinancialAnalysisService financialAnalysisService;
+
+    @Mock
+    private AuthenticatedUserResolver authenticatedUserResolver;
+
+    @Mock
+    private TransactionMapper transactionMapper;
 
     @Mock
     private CreateTransactionUseCase createTransactionUseCase;
@@ -83,10 +93,26 @@ class TransactionControllerTest {
                 20L
         );
 
+        User user = new User();
+        user.setId(1L);
+
+        CreateTransactionCommand command = new CreateTransactionCommand(
+                request.amount(),
+                request.description(),
+                request.date(),
+                request.type(),
+                request.sourceType(),
+                request.accountId(),
+                request.categoryId(),
+                user
+        );
+
         TransactionResponse transactionResponse = mock(TransactionResponse.class);
         FinancialCommitmentResponse financialAnalysis = mock(FinancialCommitmentResponse.class);
 
-        when(createTransactionUseCase.execute(request, authentication)).thenReturn(transactionResponse);
+        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
+        when(transactionMapper.toCommand(request, user)).thenReturn(command);
+        when(createTransactionUseCase.execute(command)).thenReturn(transactionResponse);
         when(financialAnalysisService.getFinancialCommitment(authentication)).thenReturn(financialAnalysis);
 
         TransactionCreationResponse result = transactionController.create(request, authentication);
@@ -94,7 +120,9 @@ class TransactionControllerTest {
         assertThat(result.transaction()).isEqualTo(transactionResponse);
         assertThat(result.analysis()).isEqualTo(financialAnalysis);
 
-        verify(createTransactionUseCase).execute(request, authentication);
+        verify(authenticatedUserResolver).resolve(authentication);
+        verify(transactionMapper).toCommand(request, user);
+        verify(createTransactionUseCase).execute(command);
         verify(financialAnalysisService).getFinancialCommitment(authentication);
     }
 

--- a/src/test/java/com/financebot/transaction/application/usecase/CreateInstallmentTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/CreateInstallmentTransactionUseCaseTest.java
@@ -3,7 +3,7 @@ package com.financebot.transaction.application.usecase;
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.transaction.application.dto.request.CreateInstallmentTransactionRequest;
+import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.dto.response.InstallmentTransactionResponse;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
@@ -16,7 +16,6 @@ import com.financebot.transaction.domain.installment.InstallmentPlanItem;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -26,7 +25,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -52,9 +50,6 @@ class CreateInstallmentTransactionUseCaseTest {
     private SaveTransactionPort saveTransactionPort;
 
     @Mock
-    private AuthenticatedUserResolver authenticatedUserResolver;
-
-    @Mock
     private UserResourceResolver userResourceResolver;
 
     @Mock
@@ -66,9 +61,6 @@ class CreateInstallmentTransactionUseCaseTest {
     @Mock
     private TransactionMapper transactionMapper;
 
-    @Mock
-    private Authentication authentication;
-
     @InjectMocks
     private CreateInstallmentTransactionUseCase createInstallmentTransactionUseCase;
 
@@ -79,17 +71,15 @@ class CreateInstallmentTransactionUseCaseTest {
         Account account = buildAccount(10L);
         Category category = buildCategory(20L, CategoryType.EXPENSE);
 
-        CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+        CreateInstallmentTransactionCommand command = buildInstallmentCommand(user);
 
         TransactionResponse response1 = mock(TransactionResponse.class);
         TransactionResponse response2 = mock(TransactionResponse.class);
         TransactionResponse response3 = mock(TransactionResponse.class);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
-        mockInstallmentCreationDependencies(user, account, category, request, response1, response2, response3);
+        mockInstallmentCreationDependencies(user, account, category, command, response1, response2, response3);
 
-        InstallmentTransactionResponse result =
-                createInstallmentTransactionUseCase.execute(request, authentication);
+        InstallmentTransactionResponse result = createInstallmentTransactionUseCase.execute(command);
 
         List<Transaction> savedTransactions = captureSavedInstallments();
 
@@ -101,49 +91,13 @@ class CreateInstallmentTransactionUseCaseTest {
         assertInstallmentResponse(result, response1, response2, response3);
 
         verify(installmentPlanFactory).create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         );
         verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
-    }
-
-    @Test
-    @DisplayName("deve criar parcelamento para usuário informado diretamente")
-    void shouldCreateInstallmentForUserSuccessfully() {
-        User user = buildUser(1L, "bryan@email.com");
-        Account account = buildAccount(10L);
-        Category category = buildCategory(20L, CategoryType.EXPENSE);
-
-        CreateInstallmentTransactionRequest request = buildInstallmentRequest();
-
-        TransactionResponse response1 = mock(TransactionResponse.class);
-        TransactionResponse response2 = mock(TransactionResponse.class);
-        TransactionResponse response3 = mock(TransactionResponse.class);
-
-        mockInstallmentCreationDependencies(user, account, category, request, response1, response2, response3);
-
-        InstallmentTransactionResponse result =
-                createInstallmentTransactionUseCase.executeForUser(request, user);
-
-        List<Transaction> savedTransactions = captureSavedInstallments();
-
-        assertThat(savedTransactions).hasSize(3);
-        assertThat(result.totalInstallments()).isEqualTo(3);
-        assertThat(result.installmentGroupId()).isEqualTo(INSTALLMENT_GROUP_ID);
-        assertThat(result.transactions()).containsExactly(response1, response2, response3);
-
-        verify(installmentPlanFactory).create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
-        );
-        verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
-        verify(authenticatedUserResolver, never()).resolve(any());
     }
 
     @Test
@@ -151,7 +105,7 @@ class CreateInstallmentTransactionUseCaseTest {
     void shouldThrowWhenInstallmentPlanRejectsIncomeTransaction() {
         User user = buildUser(1L, "bryan@email.com");
 
-        CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
+        CreateInstallmentTransactionCommand command = new CreateInstallmentTransactionCommand(
                 new BigDecimal("1000.00"),
                 "Salário parcelado",
                 LocalDate.of(2026, 4, 10),
@@ -159,19 +113,19 @@ class CreateInstallmentTransactionUseCaseTest {
                 SourceType.WEB,
                 10L,
                 20L,
-                3
+                3,
+                user
         );
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenThrow(new IllegalArgumentException("Installment transactions are allowed only for expenses"));
 
-        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Installment transactions are allowed only for expenses");
 
@@ -184,7 +138,7 @@ class CreateInstallmentTransactionUseCaseTest {
     void shouldThrowWhenInstallmentPlanRejectsTotalInstallmentsLessThanTwo() {
         User user = buildUser(1L, "bryan@email.com");
 
-        CreateInstallmentTransactionRequest request = new CreateInstallmentTransactionRequest(
+        CreateInstallmentTransactionCommand command = new CreateInstallmentTransactionCommand(
                 new BigDecimal("1000.00"),
                 "Notebook",
                 LocalDate.of(2026, 4, 10),
@@ -192,19 +146,19 @@ class CreateInstallmentTransactionUseCaseTest {
                 SourceType.WEB,
                 10L,
                 20L,
-                1
+                1,
+                user
         );
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenThrow(new IllegalArgumentException("Total installments must be at least 2"));
 
-        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Total installments must be at least 2");
 
@@ -217,21 +171,20 @@ class CreateInstallmentTransactionUseCaseTest {
     void shouldThrowWhenAccountIsNotFoundForUserOnCreateInstallment() {
         User user = buildUser(1L, "bryan@email.com");
 
-        CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+        CreateInstallmentTransactionCommand command = buildInstallmentCommand(user);
         InstallmentPlan plan = buildInstallmentPlan();
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenReturn(plan);
         when(userResourceResolver.resolveAccount(10L, 1L))
                 .thenThrow(new EntityNotFoundException("Account not found"));
 
-        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Account not found");
 
@@ -246,22 +199,21 @@ class CreateInstallmentTransactionUseCaseTest {
         User user = buildUser(1L, "bryan@email.com");
         Account account = buildAccount(10L);
 
-        CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+        CreateInstallmentTransactionCommand command = buildInstallmentCommand(user);
         InstallmentPlan plan = buildInstallmentPlan();
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenReturn(plan);
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L))
                 .thenThrow(new EntityNotFoundException("Category not found"));
 
-        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Category not found");
 
@@ -276,16 +228,15 @@ class CreateInstallmentTransactionUseCaseTest {
         Account account = buildAccount(10L);
         Category category = buildCategory(20L, CategoryType.INCOME);
 
-        CreateInstallmentTransactionRequest request = buildInstallmentRequest();
+        CreateInstallmentTransactionCommand command = buildInstallmentCommand(user);
         InstallmentPlan plan = buildInstallmentPlan();
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenReturn(plan);
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
@@ -294,7 +245,7 @@ class CreateInstallmentTransactionUseCaseTest {
                 .when(transactionCategoryValidator)
                 .validate(category, TransactionType.EXPENSE);
 
-        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createInstallmentTransactionUseCase.execute(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Category type does not match transaction type");
 
@@ -302,8 +253,8 @@ class CreateInstallmentTransactionUseCaseTest {
         verify(saveTransactionPort, never()).saveAll(anyList());
     }
 
-    private CreateInstallmentTransactionRequest buildInstallmentRequest() {
-        return new CreateInstallmentTransactionRequest(
+    private CreateInstallmentTransactionCommand buildInstallmentCommand(User user) {
+        return new CreateInstallmentTransactionCommand(
                 new BigDecimal("1000.00"),
                 "Notebook",
                 LocalDate.of(2026, 4, 10),
@@ -311,7 +262,8 @@ class CreateInstallmentTransactionUseCaseTest {
                 SourceType.WEB,
                 10L,
                 20L,
-                3
+                3,
+                user
         );
     }
 
@@ -319,7 +271,7 @@ class CreateInstallmentTransactionUseCaseTest {
             User user,
             Account account,
             Category category,
-            CreateInstallmentTransactionRequest request,
+            CreateInstallmentTransactionCommand command,
             TransactionResponse response1,
             TransactionResponse response2,
             TransactionResponse response3
@@ -327,15 +279,15 @@ class CreateInstallmentTransactionUseCaseTest {
         InstallmentPlan plan = buildInstallmentPlan();
 
         when(installmentPlanFactory.create(
-                request.totalAmount(),
-                request.description(),
-                request.firstInstallmentDate(),
-                request.type(),
-                request.totalInstallments()
+                command.totalAmount(),
+                command.description(),
+                command.firstInstallmentDate(),
+                command.type(),
+                command.totalInstallments()
         )).thenReturn(plan);
 
-        when(userResourceResolver.resolveAccount(request.accountId(), user.getId())).thenReturn(account);
-        when(userResourceResolver.resolveCategory(request.categoryId(), user.getId())).thenReturn(category);
+        when(userResourceResolver.resolveAccount(command.accountId(), user.getId())).thenReturn(account);
+        when(userResourceResolver.resolveCategory(command.categoryId(), user.getId())).thenReturn(category);
 
         when(saveTransactionPort.saveAll(anyList())).thenAnswer(invocation -> invocation.getArgument(0));
 

--- a/src/test/java/com/financebot/transaction/application/usecase/CreateTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/CreateTransactionUseCaseTest.java
@@ -3,7 +3,7 @@ package com.financebot.transaction.application.usecase;
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.transaction.application.dto.request.CreateTransactionRequest;
+import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
 import com.financebot.transaction.domain.SourceType;
@@ -12,7 +12,6 @@ import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -21,7 +20,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -43,9 +41,6 @@ class CreateTransactionUseCaseTest {
     private SaveTransactionPort saveTransactionPort;
 
     @Mock
-    private AuthenticatedUserResolver authenticatedUserResolver;
-
-    @Mock
     private UserResourceResolver userResourceResolver;
 
     @Mock
@@ -53,9 +48,6 @@ class CreateTransactionUseCaseTest {
 
     @Mock
     private TransactionMapper transactionMapper;
-
-    @Mock
-    private Authentication authentication;
 
     @InjectMocks
     private CreateTransactionUseCase createTransactionUseCase;
@@ -67,39 +59,7 @@ class CreateTransactionUseCaseTest {
         Account account = buildAccount(10L);
         Category category = buildCategory(20L, CategoryType.EXPENSE);
 
-        CreateTransactionRequest request = buildCreateTransactionRequest();
-
-        Transaction transaction = new Transaction();
-        Transaction savedTransaction = new Transaction();
-        TransactionResponse response = mock(TransactionResponse.class);
-
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
-        when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
-        when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
-        when(transactionMapper.toEntity(request)).thenReturn(transaction);
-        when(saveTransactionPort.save(transaction)).thenReturn(savedTransaction);
-        when(transactionMapper.toResponse(savedTransaction)).thenReturn(response);
-
-        TransactionResponse result = createTransactionUseCase.execute(request, authentication);
-
-        assertThat(result).isEqualTo(response);
-        assertTransactionLinkedToUserResources(transaction, user, account, category);
-        assertTransactionMarkedAsNonInstallment(transaction);
-
-        verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
-        verify(transactionMapper).toEntity(request);
-        verify(saveTransactionPort).save(transaction);
-        verify(transactionMapper).toResponse(savedTransaction);
-    }
-
-    @Test
-    @DisplayName("deve criar transação usando usuário já resolvido")
-    void shouldCreateTransactionForResolvedUser() {
-        User user = buildUser(1L, "bryan@email.com");
-        Account account = buildAccount(10L);
-        Category category = buildCategory(20L, CategoryType.EXPENSE);
-
-        CreateTransactionRequest request = buildCreateTransactionRequest();
+        CreateTransactionCommand command = buildCreateTransactionCommand(user);
 
         Transaction transaction = new Transaction();
         Transaction savedTransaction = new Transaction();
@@ -107,19 +67,18 @@ class CreateTransactionUseCaseTest {
 
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
-        when(transactionMapper.toEntity(request)).thenReturn(transaction);
+        when(transactionMapper.toEntity(command)).thenReturn(transaction);
         when(saveTransactionPort.save(transaction)).thenReturn(savedTransaction);
         when(transactionMapper.toResponse(savedTransaction)).thenReturn(response);
 
-        TransactionResponse result = createTransactionUseCase.executeForUser(request, user);
+        TransactionResponse result = createTransactionUseCase.execute(command);
 
         assertThat(result).isEqualTo(response);
         assertTransactionLinkedToUserResources(transaction, user, account, category);
         assertTransactionMarkedAsNonInstallment(transaction);
 
-        verifyNoInteractions(authenticatedUserResolver);
         verify(transactionCategoryValidator).validate(category, TransactionType.EXPENSE);
-        verify(transactionMapper).toEntity(request);
+        verify(transactionMapper).toEntity(command);
         verify(saveTransactionPort).save(transaction);
         verify(transactionMapper).toResponse(savedTransaction);
     }
@@ -128,13 +87,12 @@ class CreateTransactionUseCaseTest {
     @DisplayName("deve lançar erro quando conta não pertencer ao usuário")
     void shouldThrowWhenAccountIsNotFoundForUser() {
         User user = buildUser(1L, "bryan@email.com");
-        CreateTransactionRequest request = buildCreateTransactionRequest();
+        CreateTransactionCommand command = buildCreateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(userResourceResolver.resolveAccount(10L, 1L))
                 .thenThrow(new EntityNotFoundException("Account not found"));
 
-        assertThatThrownBy(() -> createTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Account not found");
 
@@ -147,14 +105,13 @@ class CreateTransactionUseCaseTest {
     void shouldThrowWhenCategoryIsNotFoundForUser() {
         User user = buildUser(1L, "bryan@email.com");
         Account account = buildAccount(10L);
-        CreateTransactionRequest request = buildCreateTransactionRequest();
+        CreateTransactionCommand command = buildCreateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L))
                 .thenThrow(new EntityNotFoundException("Category not found"));
 
-        assertThatThrownBy(() -> createTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Category not found");
 
@@ -167,9 +124,8 @@ class CreateTransactionUseCaseTest {
         User user = buildUser(1L, "bryan@email.com");
         Account account = buildAccount(10L);
         Category category = buildCategory(20L, CategoryType.INCOME);
-        CreateTransactionRequest request = buildCreateTransactionRequest();
+        CreateTransactionCommand command = buildCreateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
 
@@ -177,7 +133,7 @@ class CreateTransactionUseCaseTest {
                 .when(transactionCategoryValidator)
                 .validate(category, TransactionType.EXPENSE);
 
-        assertThatThrownBy(() -> createTransactionUseCase.execute(request, authentication))
+        assertThatThrownBy(() -> createTransactionUseCase.execute(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Category type does not match transaction type");
 
@@ -202,15 +158,16 @@ class CreateTransactionUseCaseTest {
         assertThat(transaction.getInstallmentGroupId()).isNull();
     }
 
-    private CreateTransactionRequest buildCreateTransactionRequest() {
-        return new CreateTransactionRequest(
+    private CreateTransactionCommand buildCreateTransactionCommand(User user) {
+        return new CreateTransactionCommand(
                 new BigDecimal("150.00"),
                 "Mercado",
                 LocalDate.of(2026, 4, 4),
                 TransactionType.EXPENSE,
                 SourceType.WEB,
                 10L,
-                20L
+                20L,
+                user
         );
     }
 

--- a/src/test/java/com/financebot/transaction/application/usecase/UpdateTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/UpdateTransactionUseCaseTest.java
@@ -3,7 +3,7 @@ package com.financebot.transaction.application.usecase;
 import com.financebot.account.domain.Account;
 import com.financebot.category.domain.Category;
 import com.financebot.category.domain.CategoryType;
-import com.financebot.transaction.application.dto.request.UpdateTransactionRequest;
+import com.financebot.transaction.application.command.UpdateTransactionCommand;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
@@ -13,7 +13,6 @@ import com.financebot.transaction.domain.TransactionType;
 import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.transaction.validation.TransactionCategoryValidator;
 import com.financebot.user.domain.User;
-import com.financebot.user.service.AuthenticatedUserResolver;
 import com.financebot.user.service.UserResourceResolver;
 import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -22,7 +21,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -48,9 +46,6 @@ class UpdateTransactionUseCaseTest {
     private SaveTransactionPort saveTransactionPort;
 
     @Mock
-    private AuthenticatedUserResolver authenticatedUserResolver;
-
-    @Mock
     private UserResourceResolver userResourceResolver;
 
     @Mock
@@ -58,9 +53,6 @@ class UpdateTransactionUseCaseTest {
 
     @Mock
     private TransactionMapper transactionMapper;
-
-    @Mock
-    private Authentication authentication;
 
     @InjectMocks
     private UpdateTransactionUseCase updateTransactionUseCase;
@@ -74,23 +66,25 @@ class UpdateTransactionUseCaseTest {
         Category category = buildCategory(20L, CategoryType.INCOME);
         TransactionResponse response = mock(TransactionResponse.class);
 
-        UpdateTransactionRequest request = buildUpdateTransactionRequest();
+        UpdateTransactionCommand command = buildUpdateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(findTransactionPort.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
         when(saveTransactionPort.save(transaction)).thenReturn(transaction);
         when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
-        TransactionResponse result = updateTransactionUseCase.execute(77L, request, authentication);
+        TransactionResponse result = updateTransactionUseCase.execute(command);
 
         assertThat(result).isEqualTo(response);
         assertThat(transaction.getAccount()).isEqualTo(account);
         assertThat(transaction.getCategory()).isEqualTo(category);
 
+        verify(findTransactionPort).findByIdAndUserId(77L, 1L);
+        verify(userResourceResolver).resolveAccount(10L, 1L);
+        verify(userResourceResolver).resolveCategory(20L, 1L);
         verify(transactionCategoryValidator).validate(category, TransactionType.INCOME);
-        verify(transactionMapper).updateEntity(request, transaction);
+        verify(transactionMapper).updateEntity(command, transaction);
         verify(saveTransactionPort).save(transaction);
         verify(transactionMapper).toResponse(transaction);
     }
@@ -99,12 +93,11 @@ class UpdateTransactionUseCaseTest {
     @DisplayName("deve lançar erro quando transação a atualizar não existir")
     void shouldThrowWhenTransactionToUpdateDoesNotExist() {
         User user = buildUser(1L, "bryan@email.com");
-        UpdateTransactionRequest request = buildUpdateTransactionRequest();
+        UpdateTransactionCommand command = buildUpdateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(findTransactionPort.findByIdAndUserId(77L, 1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> updateTransactionUseCase.execute(77L, request, authentication))
+        assertThatThrownBy(() -> updateTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Transaction not found");
 
@@ -116,20 +109,19 @@ class UpdateTransactionUseCaseTest {
     void shouldThrowWhenAccountForUpdateIsNotFound() {
         User user = buildUser(1L, "bryan@email.com");
         Transaction transaction = new Transaction();
-        UpdateTransactionRequest request = buildUpdateTransactionRequest();
+        UpdateTransactionCommand command = buildUpdateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(findTransactionPort.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
         when(userResourceResolver.resolveAccount(10L, 1L))
                 .thenThrow(new EntityNotFoundException("Account not found"));
 
-        assertThatThrownBy(() -> updateTransactionUseCase.execute(77L, request, authentication))
+        assertThatThrownBy(() -> updateTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Account not found");
 
         verify(userResourceResolver, never()).resolveCategory(any(), any());
         verifyNoInteractions(transactionCategoryValidator);
-        verify(transactionMapper, never()).updateEntity(any(), any());
+        verify(transactionMapper, never()).updateEntity(any(UpdateTransactionCommand.class), any(Transaction.class));
         verify(saveTransactionPort, never()).save(any());
     }
 
@@ -139,20 +131,19 @@ class UpdateTransactionUseCaseTest {
         User user = buildUser(1L, "bryan@email.com");
         Transaction transaction = new Transaction();
         Account account = buildAccount(10L);
-        UpdateTransactionRequest request = buildUpdateTransactionRequest();
+        UpdateTransactionCommand command = buildUpdateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(findTransactionPort.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L))
                 .thenThrow(new EntityNotFoundException("Category not found"));
 
-        assertThatThrownBy(() -> updateTransactionUseCase.execute(77L, request, authentication))
+        assertThatThrownBy(() -> updateTransactionUseCase.execute(command))
                 .isInstanceOf(EntityNotFoundException.class)
                 .hasMessage("Category not found");
 
         verifyNoInteractions(transactionCategoryValidator);
-        verify(transactionMapper, never()).updateEntity(any(), any());
+        verify(transactionMapper, never()).updateEntity(any(UpdateTransactionCommand.class), any(Transaction.class));
         verify(saveTransactionPort, never()).save(any());
     }
 
@@ -163,9 +154,8 @@ class UpdateTransactionUseCaseTest {
         Transaction transaction = new Transaction();
         Account account = buildAccount(10L);
         Category category = buildCategory(20L, CategoryType.EXPENSE);
-        UpdateTransactionRequest request = buildUpdateTransactionRequest();
+        UpdateTransactionCommand command = buildUpdateTransactionCommand(user);
 
-        when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
         when(findTransactionPort.findByIdAndUserId(77L, 1L)).thenReturn(Optional.of(transaction));
         when(userResourceResolver.resolveAccount(10L, 1L)).thenReturn(account);
         when(userResourceResolver.resolveCategory(20L, 1L)).thenReturn(category);
@@ -174,23 +164,25 @@ class UpdateTransactionUseCaseTest {
                 .when(transactionCategoryValidator)
                 .validate(category, TransactionType.INCOME);
 
-        assertThatThrownBy(() -> updateTransactionUseCase.execute(77L, request, authentication))
+        assertThatThrownBy(() -> updateTransactionUseCase.execute(command))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Category type does not match transaction type");
 
-        verify(transactionMapper, never()).updateEntity(any(), any());
+        verify(transactionMapper, never()).updateEntity(any(UpdateTransactionCommand.class), any(Transaction.class));
         verify(saveTransactionPort, never()).save(any());
     }
 
-    private UpdateTransactionRequest buildUpdateTransactionRequest() {
-        return new UpdateTransactionRequest(
+    private UpdateTransactionCommand buildUpdateTransactionCommand(User user) {
+        return new UpdateTransactionCommand(
+                77L,
                 new BigDecimal("500.00"),
                 "Salário",
                 LocalDate.of(2026, 4, 5),
                 TransactionType.INCOME,
                 SourceType.WEB,
                 10L,
-                20L
+                20L,
+                user
         );
     }
 


### PR DESCRIPTION
## Objetivo

Separar os DTOs de request HTTP dos commands internos usados pelos use cases de transações, reduzindo o acoplamento da camada de aplicação com contratos da API e deixando os fluxos mais próximos de uma arquitetura hexagonal.

## Alterações realizadas

- Adicionado `CreateTransactionCommand` para criação comum de transações.
- Adicionado `CreateInstallmentTransactionCommand` para criação de transações parceladas.
- Adicionado `UpdateTransactionCommand` para atualização de transações.
- Refatorado `CreateTransactionUseCase` para receber command interno em vez de DTO HTTP e `Authentication`.
- Refatorado `CreateInstallmentTransactionUseCase` para receber command interno em vez de DTO HTTP e `Authentication`.
- Refatorado `UpdateTransactionUseCase` para receber command interno em vez de DTO HTTP e `Authentication`.
- Atualizado `TransactionController` para converter requests HTTP em commands antes de chamar os use cases.
- Atualizado `TelegramIntegrationService` para criar transações comuns e parceladas usando commands internos.
- Removidos mapeamentos obsoletos de DTO HTTP para entidade no fluxo principal de transações.
- Atualizados testes unitários de use cases, controller e integração Telegram para validar os novos commands.
- Adicionado teste para garantir que o fluxo de parcelamento via Telegram delega corretamente para `CreateInstallmentTransactionUseCase`.
- Atualizado `CHANGELOG.md` com a separação entre DTOs HTTP e commands internos.

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [x] Testes
- [x] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [x] Executei `./mvnw clean verify`
- [x] Os testes automatizados passaram
- [x] Rodei análise local no SonarQube quando houve alteração relevante
- [x] O Quality Gate continua aprovado quando houve análise SonarQube
- [x] Não introduzi novas issues críticas de Security ou Reliability
- [x] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [x] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- `./mvnw clean verify` executado com sucesso.
- Todos os testes automatizados passaram.
- Testes atualizados para validar criação comum, criação parcelada e atualização de transações usando commands internos.
- Teste adicional incluído para validar delegação do parcelamento via Telegram para `CreateInstallmentTransactionUseCase`.
- `CHANGELOG.md` atualizado com as mudanças da refatoração.

## Testes realizados

- [x] `./mvnw clean verify`
- [x] Testes unitários específicos
- [ ] Teste manual
- [x] Análise SonarQube local
- [ ] Não se aplica

## Issue relacionada

Closes #64