### PR TITLE
Refactor/remove pageable from transaction application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## v1.2.1
+
 ### Changed
 - Refatorado o módulo de transações para uma estrutura mais próxima da arquitetura hexagonal.
 - Extraídos casos de uso para criação, listagem, busca, atualização, remoção e parcelamento de transações.
@@ -12,16 +14,23 @@
 - Ajustado o fluxo de parcelamento para `CreateInstallmentTransactionUseCase` receber `CreateInstallmentTransactionCommand`.
 - Ajustado o fluxo de atualização para `UpdateTransactionUseCase` receber `UpdateTransactionCommand`.
 - Ajustado o fluxo do Telegram para criar transações comuns e parceladas usando commands internos em vez de DTOs HTTP.
+- Removida a dependência direta de `Page` e `Pageable` da camada application de transações.
+- Ajustado `ListTransactionsUseCase` e `FindTransactionPort` para usar tipos neutros de paginação.
+- Adaptado `TransactionPersistenceAdapter` para converter paginação neutra para Spring Data.
 
 ### Added
 - Adicionados ports de saída para persistência de transações.
 - Adicionado `TransactionPersistenceAdapter`.
+- Adicionados `PageQuery`, `PageResult`, `PageSort` e `SortDirection` como tipos neutros de paginação.
+- Adicionado mapper de paginação entre Spring Data e tipos internos no adapter web.
 
 ### Tests
 - Adicionados testes unitários para use cases, controller e adapter de persistência de transações.
 - Atualizados testes de use cases, controller e integração Telegram para os novos commands internos.
 - Adicionada cobertura para criação parcelada via Telegram delegando para `CreateInstallmentTransactionCommand`.
-- 
+- Adicionados testes para o mapper de paginação.
+- Atualizados testes de listagem, controller e adapter de persistência de transações para os tipos neutros de paginação.
+
 ## v1.2.0
 
 ### Added

--- a/src/main/java/com/financebot/common/pagination/PageQuery.java
+++ b/src/main/java/com/financebot/common/pagination/PageQuery.java
@@ -1,9 +1,10 @@
 package com.financebot.common.pagination;
 
+import java.util.List;
+
 public record PageQuery(
         int page,
         int size,
-        String sortBy,
-        SortDirection direction
+        List<PageSort> sorts
 ) {
 }

--- a/src/main/java/com/financebot/common/pagination/PageQuery.java
+++ b/src/main/java/com/financebot/common/pagination/PageQuery.java
@@ -1,0 +1,9 @@
+package com.financebot.common.pagination;
+
+public record PageQuery(
+        int page,
+        int size,
+        String sortBy,
+        SortDirection direction
+) {
+}

--- a/src/main/java/com/financebot/common/pagination/PageResult.java
+++ b/src/main/java/com/financebot/common/pagination/PageResult.java
@@ -1,0 +1,29 @@
+package com.financebot.common.pagination;
+
+import java.util.List;
+import java.util.function.Function;
+
+public record PageResult<T>(
+        List<T> content,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        boolean first,
+        boolean last
+) {
+
+    public <R> PageResult<R> map(Function<T, R> mapper) {
+        return new PageResult<>(
+                content.stream()
+                        .map(mapper)
+                        .toList(),
+                page,
+                size,
+                totalElements,
+                totalPages,
+                first,
+                last
+        );
+    }
+}

--- a/src/main/java/com/financebot/common/pagination/PageSort.java
+++ b/src/main/java/com/financebot/common/pagination/PageSort.java
@@ -1,0 +1,7 @@
+package com.financebot.common.pagination;
+
+public record PageSort(
+        String property,
+        SortDirection direction
+) {
+}

--- a/src/main/java/com/financebot/common/pagination/SortDirection.java
+++ b/src/main/java/com/financebot/common/pagination/SortDirection.java
@@ -1,0 +1,6 @@
+package com.financebot.common.pagination;
+
+public enum SortDirection {
+    ASC,
+    DESC
+}

--- a/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
@@ -4,6 +4,9 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.transaction.adapter.in.web.mapper.SpringPageMapper;
 import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.command.UpdateTransactionCommand;
@@ -109,7 +112,12 @@ public class TransactionController {
                 description
         );
 
-        return listTransactionsUseCase.execute(filter, authentication, pageable);
+        PageQuery pageQuery = SpringPageMapper.toPageQuery(pageable);
+
+        PageResult<TransactionResponse> result =
+                listTransactionsUseCase.execute(filter, authentication, pageQuery);
+
+        return SpringPageMapper.toSpringPage(result);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/TransactionController.java
@@ -117,7 +117,7 @@ public class TransactionController {
         PageResult<TransactionResponse> result =
                 listTransactionsUseCase.execute(filter, authentication, pageQuery);
 
-        return SpringPageMapper.toSpringPage(result);
+        return SpringPageMapper.toSpringPage(result, pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapper.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapper.java
@@ -1,0 +1,44 @@
+package com.financebot.transaction.adapter.in.web.mapper;
+
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+public class SpringPageMapper {
+
+    private static final String DEFAULT_SORT_PROPERTY = "date";
+
+    private SpringPageMapper() {
+    }
+
+    public static PageQuery toPageQuery(Pageable pageable) {
+        Sort.Order order = pageable.getSort()
+                .stream()
+                .findFirst()
+                .orElse(Sort.Order.desc(DEFAULT_SORT_PROPERTY));
+
+        return new PageQuery(
+                pageable.getPageNumber(),
+                pageable.getPageSize(),
+                order.getProperty(),
+                order.isAscending() ? SortDirection.ASC : SortDirection.DESC
+        );
+    }
+
+    public static <T> PageImpl<T> toSpringPage(PageResult<T> pageResult) {
+        Pageable pageable = PageRequest.of(
+                pageResult.page(),
+                pageResult.size()
+        );
+
+        return new PageImpl<>(
+                pageResult.content(),
+                pageable,
+                pageResult.totalElements()
+        );
+    }
+}

--- a/src/main/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapper.java
+++ b/src/main/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapper.java
@@ -2,39 +2,35 @@ package com.financebot.transaction.adapter.in.web.mapper;
 
 import com.financebot.common.pagination.PageQuery;
 import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.PageSort;
 import com.financebot.common.pagination.SortDirection;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+
+import java.util.List;
 
 public class SpringPageMapper {
-
-    private static final String DEFAULT_SORT_PROPERTY = "date";
 
     private SpringPageMapper() {
     }
 
     public static PageQuery toPageQuery(Pageable pageable) {
-        Sort.Order order = pageable.getSort()
+        List<PageSort> sorts = pageable.getSort()
                 .stream()
-                .findFirst()
-                .orElse(Sort.Order.desc(DEFAULT_SORT_PROPERTY));
+                .map(order -> new PageSort(
+                        order.getProperty(),
+                        order.isAscending() ? SortDirection.ASC : SortDirection.DESC
+                ))
+                .toList();
 
         return new PageQuery(
                 pageable.getPageNumber(),
                 pageable.getPageSize(),
-                order.getProperty(),
-                order.isAscending() ? SortDirection.ASC : SortDirection.DESC
+                sorts
         );
     }
 
-    public static <T> PageImpl<T> toSpringPage(PageResult<T> pageResult) {
-        Pageable pageable = PageRequest.of(
-                pageResult.page(),
-                pageResult.size()
-        );
-
+    public static <T> PageImpl<T> toSpringPage(PageResult<T> pageResult, Pageable pageable) {
         return new PageImpl<>(
                 pageResult.content(),
                 pageable,

--- a/src/main/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapter.java
+++ b/src/main/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapter.java
@@ -1,5 +1,8 @@
 package com.financebot.transaction.adapter.out.persistence;
 
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.application.port.out.DeleteTransactionPort;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
 import com.financebot.transaction.application.port.out.SaveTransactionPort;
@@ -9,7 +12,8 @@ import com.financebot.transaction.repository.TransactionRepository;
 import com.financebot.transaction.specification.TransactionSpecification;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -37,15 +41,47 @@ public class TransactionPersistenceAdapter implements SaveTransactionPort, FindT
     }
 
     @Override
-    public Page<Transaction> findAllByFilter(Long userId, TransactionFilter filter, Pageable pageable) {
-        return transactionRepository.findAll(
+    public PageResult<Transaction> findAllByFilter(
+            Long userId,
+            TransactionFilter filter,
+            PageQuery pageQuery
+    ) {
+        PageRequest pageRequest = toPageRequest(pageQuery);
+
+        Page<Transaction> page = transactionRepository.findAll(
                 TransactionSpecification.withFilters(userId, filter),
-                pageable
+                pageRequest
         );
+
+        return toPageResult(page);
     }
 
     @Override
     public void delete(Transaction transaction) {
         transactionRepository.delete(transaction);
+    }
+
+    private PageRequest toPageRequest(PageQuery pageQuery) {
+        Sort.Direction direction = pageQuery.direction() == SortDirection.ASC
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
+
+        return PageRequest.of(
+                pageQuery.page(),
+                pageQuery.size(),
+                Sort.by(direction, pageQuery.sortBy())
+        );
+    }
+
+    private PageResult<Transaction> toPageResult(Page<Transaction> page) {
+        return new PageResult<>(
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalElements(),
+                page.getTotalPages(),
+                page.isFirst(),
+                page.isLast()
+        );
     }
 }

--- a/src/main/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapter.java
+++ b/src/main/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapter.java
@@ -2,6 +2,7 @@ package com.financebot.transaction.adapter.out.persistence;
 
 import com.financebot.common.pagination.PageQuery;
 import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.PageSort;
 import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.application.port.out.DeleteTransactionPort;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
@@ -62,15 +63,34 @@ public class TransactionPersistenceAdapter implements SaveTransactionPort, FindT
     }
 
     private PageRequest toPageRequest(PageQuery pageQuery) {
-        Sort.Direction direction = pageQuery.direction() == SortDirection.ASC
-                ? Sort.Direction.ASC
-                : Sort.Direction.DESC;
+        Sort sort = toSpringSort(pageQuery.sorts());
 
         return PageRequest.of(
                 pageQuery.page(),
                 pageQuery.size(),
-                Sort.by(direction, pageQuery.sortBy())
+                sort
         );
+    }
+
+    private Sort toSpringSort(List<PageSort> sorts) {
+        if (sorts == null || sorts.isEmpty()) {
+            return Sort.unsorted();
+        }
+
+        List<Sort.Order> orders = sorts.stream()
+                .map(sort -> new Sort.Order(
+                        toSpringDirection(sort.direction()),
+                        sort.property()
+                ))
+                .toList();
+
+        return Sort.by(orders);
+    }
+
+    private Sort.Direction toSpringDirection(SortDirection direction) {
+        return direction == SortDirection.ASC
+                ? Sort.Direction.ASC
+                : Sort.Direction.DESC;
     }
 
     private PageResult<Transaction> toPageResult(Page<Transaction> page) {

--- a/src/main/java/com/financebot/transaction/application/port/out/FindTransactionPort.java
+++ b/src/main/java/com/financebot/transaction/application/port/out/FindTransactionPort.java
@@ -1,9 +1,9 @@
 package com.financebot.transaction.application.port.out;
 
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.dto.TransactionFilter;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.Optional;
 
@@ -11,5 +11,9 @@ public interface FindTransactionPort {
 
     Optional<Transaction> findByIdAndUserId(Long transactionId, Long userId);
 
-    Page<Transaction> findAllByFilter(Long userId, TransactionFilter filter, Pageable pageable);
+    PageResult<Transaction> findAllByFilter(
+            Long userId,
+            TransactionFilter filter,
+            PageQuery pageQuery
+    );
 }

--- a/src/main/java/com/financebot/transaction/application/usecase/ListTransactionsUseCase.java
+++ b/src/main/java/com/financebot/transaction/application/usecase/ListTransactionsUseCase.java
@@ -1,5 +1,7 @@
 package com.financebot.transaction.application.usecase;
 
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
 import com.financebot.transaction.dto.TransactionFilter;
@@ -7,8 +9,6 @@ import com.financebot.transaction.mapper.TransactionMapper;
 import com.financebot.user.domain.User;
 import com.financebot.user.service.AuthenticatedUserResolver;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,16 +26,16 @@ public class ListTransactionsUseCase {
     private final AuthenticatedUserResolver authenticatedUserResolver;
 
     @Transactional(readOnly = true)
-    public Page<TransactionResponse> execute(
+    public PageResult<TransactionResponse> execute(
             TransactionFilter filter,
             Authentication authentication,
-            Pageable pageable
+            PageQuery pageQuery
     ) {
         User user = authenticatedUserResolver.resolve(authentication);
 
         validatePeriod(filter.startDate(), filter.endDate());
 
-        return findTransactionPort.findAllByFilter(user.getId(), filter, pageable)
+        return findTransactionPort.findAllByFilter(user.getId(), filter, pageQuery)
                 .map(transactionMapper::toResponse);
     }
 
@@ -45,4 +45,3 @@ public class ListTransactionsUseCase {
         }
     }
 }
-

--- a/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
@@ -4,6 +4,9 @@ import com.financebot.analysis.dto.response.FinancialCommitmentResponse;
 import com.financebot.analysis.dto.response.InstallmentTransactionCreationResponse;
 import com.financebot.analysis.dto.response.TransactionCreationResponse;
 import com.financebot.analysis.service.FinancialAnalysisService;
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.application.command.CreateInstallmentTransactionCommand;
 import com.financebot.transaction.application.command.CreateTransactionCommand;
 import com.financebot.transaction.application.command.UpdateTransactionCommand;
@@ -34,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 
 import java.math.BigDecimal;
@@ -41,6 +45,8 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -179,25 +185,28 @@ class TransactionControllerTest {
     @Test
     @DisplayName("deve listar transações usando filtros recebidos pela requisição")
     void shouldFindAllTransactionsWithFilters() {
-        Pageable pageable = PageRequest.of(0, 10);
+        Pageable pageable = PageRequest.of(
+                0,
+                10,
+                Sort.by(Sort.Order.desc("date"), Sort.Order.asc("amount"))
+        );
 
         TransactionResponse transactionResponse = mock(TransactionResponse.class);
 
-        com.financebot.common.pagination.PageResult<TransactionResponse> pageResult =
-                new com.financebot.common.pagination.PageResult<>(
-                        List.of(transactionResponse),
-                        0,
-                        10,
-                        1,
-                        1,
-                        true,
-                        true
-                );
+        PageResult<TransactionResponse> pageResult = new PageResult<>(
+                List.of(transactionResponse),
+                0,
+                10,
+                1,
+                1,
+                true,
+                true
+        );
 
         when(listTransactionsUseCase.execute(
-                org.mockito.ArgumentMatchers.any(TransactionFilter.class),
-                org.mockito.ArgumentMatchers.eq(authentication),
-                org.mockito.ArgumentMatchers.any(com.financebot.common.pagination.PageQuery.class)
+                any(TransactionFilter.class),
+                eq(authentication),
+                any(PageQuery.class)
         )).thenReturn(pageResult);
 
         Page<TransactionResponse> result = transactionController.findAll(
@@ -216,14 +225,14 @@ class TransactionControllerTest {
         assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getNumber()).isZero();
         assertThat(result.getSize()).isEqualTo(10);
+        assertThat(result.getSort()).isEqualTo(pageable.getSort());
 
         ArgumentCaptor<TransactionFilter> filterCaptor = ArgumentCaptor.forClass(TransactionFilter.class);
-        ArgumentCaptor<com.financebot.common.pagination.PageQuery> pageQueryCaptor =
-                ArgumentCaptor.forClass(com.financebot.common.pagination.PageQuery.class);
+        ArgumentCaptor<PageQuery> pageQueryCaptor = ArgumentCaptor.forClass(PageQuery.class);
 
         verify(listTransactionsUseCase).execute(
                 filterCaptor.capture(),
-                org.mockito.ArgumentMatchers.eq(authentication),
+                eq(authentication),
                 pageQueryCaptor.capture()
         );
 
@@ -237,13 +246,17 @@ class TransactionControllerTest {
         assertThat(capturedFilter.sourceType()).isEqualTo(SourceType.WEB);
         assertThat(capturedFilter.description()).isEqualTo("mercado");
 
-        com.financebot.common.pagination.PageQuery capturedPageQuery = pageQueryCaptor.getValue();
+        PageQuery capturedPageQuery = pageQueryCaptor.getValue();
 
         assertThat(capturedPageQuery.page()).isZero();
         assertThat(capturedPageQuery.size()).isEqualTo(10);
-        assertThat(capturedPageQuery.sortBy()).isEqualTo("date");
-        assertThat(capturedPageQuery.direction())
-                .isEqualTo(com.financebot.common.pagination.SortDirection.DESC);
+        assertThat(capturedPageQuery.sorts()).hasSize(2);
+
+        assertThat(capturedPageQuery.sorts().get(0).property()).isEqualTo("date");
+        assertThat(capturedPageQuery.sorts().get(0).direction()).isEqualTo(SortDirection.DESC);
+
+        assertThat(capturedPageQuery.sorts().get(1).property()).isEqualTo("amount");
+        assertThat(capturedPageQuery.sorts().get(1).direction()).isEqualTo(SortDirection.ASC);
     }
 
     @Test

--- a/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/TransactionControllerTest.java
@@ -32,7 +32,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.Authentication;
@@ -183,13 +182,23 @@ class TransactionControllerTest {
         Pageable pageable = PageRequest.of(0, 10);
 
         TransactionResponse transactionResponse = mock(TransactionResponse.class);
-        Page<TransactionResponse> expectedPage = new PageImpl<>(List.of(transactionResponse), pageable, 1);
+
+        com.financebot.common.pagination.PageResult<TransactionResponse> pageResult =
+                new com.financebot.common.pagination.PageResult<>(
+                        List.of(transactionResponse),
+                        0,
+                        10,
+                        1,
+                        1,
+                        true,
+                        true
+                );
 
         when(listTransactionsUseCase.execute(
                 org.mockito.ArgumentMatchers.any(TransactionFilter.class),
                 org.mockito.ArgumentMatchers.eq(authentication),
-                org.mockito.ArgumentMatchers.eq(pageable)
-        )).thenReturn(expectedPage);
+                org.mockito.ArgumentMatchers.any(com.financebot.common.pagination.PageQuery.class)
+        )).thenReturn(pageResult);
 
         Page<TransactionResponse> result = transactionController.findAll(
                 TransactionType.EXPENSE,
@@ -203,14 +212,19 @@ class TransactionControllerTest {
                 pageable
         );
 
-        assertThat(result).isEqualTo(expectedPage);
+        assertThat(result.getContent()).containsExactly(transactionResponse);
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getNumber()).isZero();
+        assertThat(result.getSize()).isEqualTo(10);
 
         ArgumentCaptor<TransactionFilter> filterCaptor = ArgumentCaptor.forClass(TransactionFilter.class);
+        ArgumentCaptor<com.financebot.common.pagination.PageQuery> pageQueryCaptor =
+                ArgumentCaptor.forClass(com.financebot.common.pagination.PageQuery.class);
 
         verify(listTransactionsUseCase).execute(
                 filterCaptor.capture(),
                 org.mockito.ArgumentMatchers.eq(authentication),
-                org.mockito.ArgumentMatchers.eq(pageable)
+                pageQueryCaptor.capture()
         );
 
         TransactionFilter capturedFilter = filterCaptor.getValue();
@@ -222,6 +236,14 @@ class TransactionControllerTest {
         assertThat(capturedFilter.endDate()).isEqualTo(LocalDate.of(2026, 4, 30));
         assertThat(capturedFilter.sourceType()).isEqualTo(SourceType.WEB);
         assertThat(capturedFilter.description()).isEqualTo("mercado");
+
+        com.financebot.common.pagination.PageQuery capturedPageQuery = pageQueryCaptor.getValue();
+
+        assertThat(capturedPageQuery.page()).isZero();
+        assertThat(capturedPageQuery.size()).isEqualTo(10);
+        assertThat(capturedPageQuery.sortBy()).isEqualTo("date");
+        assertThat(capturedPageQuery.direction())
+                .isEqualTo(com.financebot.common.pagination.SortDirection.DESC);
     }
 
     @Test

--- a/src/test/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapperTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/in/web/mapper/SpringPageMapperTest.java
@@ -1,0 +1,115 @@
+package com.financebot.transaction.adapter.in.web.mapper;
+
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SpringPageMapperTest {
+
+    @Test
+    @DisplayName("deve converter pageable sem sort para page query sem sort")
+    void shouldConvertUnsortedPageableToUnsortedPageQuery() {
+        PageRequest pageable = PageRequest.of(0, 10);
+
+        PageQuery result = SpringPageMapper.toPageQuery(pageable);
+
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.sorts()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("deve converter pageable com sort asc para page query")
+    void shouldConvertAscendingSortToPageQuery() {
+        PageRequest pageable = PageRequest.of(
+                1,
+                20,
+                Sort.by(Sort.Direction.ASC, "amount")
+        );
+
+        PageQuery result = SpringPageMapper.toPageQuery(pageable);
+
+        assertThat(result.page()).isEqualTo(1);
+        assertThat(result.size()).isEqualTo(20);
+        assertThat(result.sorts()).hasSize(1);
+        assertThat(result.sorts().get(0).property()).isEqualTo("amount");
+        assertThat(result.sorts().get(0).direction()).isEqualTo(SortDirection.ASC);
+    }
+
+    @Test
+    @DisplayName("deve converter pageable com sort desc para page query")
+    void shouldConvertDescendingSortToPageQuery() {
+        PageRequest pageable = PageRequest.of(
+                0,
+                10,
+                Sort.by(Sort.Direction.DESC, "date")
+        );
+
+        PageQuery result = SpringPageMapper.toPageQuery(pageable);
+
+        assertThat(result.sorts()).hasSize(1);
+        assertThat(result.sorts().get(0).property()).isEqualTo("date");
+        assertThat(result.sorts().get(0).direction()).isEqualTo(SortDirection.DESC);
+    }
+
+    @Test
+    @DisplayName("deve preservar multiplos sorts ao converter pageable para page query")
+    void shouldPreserveMultipleSortsWhenConvertingToPageQuery() {
+        PageRequest pageable = PageRequest.of(
+                0,
+                10,
+                Sort.by(
+                        Sort.Order.desc("date"),
+                        Sort.Order.asc("amount")
+                )
+        );
+
+        PageQuery result = SpringPageMapper.toPageQuery(pageable);
+
+        assertThat(result.sorts()).hasSize(2);
+
+        assertThat(result.sorts().get(0).property()).isEqualTo("date");
+        assertThat(result.sorts().get(0).direction()).isEqualTo(SortDirection.DESC);
+
+        assertThat(result.sorts().get(1).property()).isEqualTo("amount");
+        assertThat(result.sorts().get(1).direction()).isEqualTo(SortDirection.ASC);
+    }
+
+    @Test
+    @DisplayName("deve converter page result para page preservando pageable original")
+    void shouldConvertPageResultToSpringPagePreservingOriginalPageable() {
+        PageRequest pageable = PageRequest.of(
+                2,
+                5,
+                Sort.by(Sort.Direction.DESC, "date")
+        );
+
+        PageResult<String> pageResult = new PageResult<>(
+                List.of("item-1", "item-2"),
+                2,
+                5,
+                12,
+                3,
+                false,
+                true
+        );
+
+        Page<String> result = SpringPageMapper.toSpringPage(pageResult, pageable);
+
+        assertThat(result.getContent()).containsExactly("item-1", "item-2");
+        assertThat(result.getNumber()).isEqualTo(2);
+        assertThat(result.getSize()).isEqualTo(5);
+        assertThat(result.getTotalElements()).isEqualTo(12);
+        assertThat(result.getTotalPages()).isEqualTo(3);
+        assertThat(result.getSort()).isEqualTo(pageable.getSort());
+    }
+}

--- a/src/test/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapterTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapterTest.java
@@ -2,6 +2,7 @@ package com.financebot.transaction.adapter.out.persistence;
 
 import com.financebot.common.pagination.PageQuery;
 import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.PageSort;
 import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
@@ -115,8 +116,7 @@ class TransactionPersistenceAdapterTest {
         PageQuery pageQuery = new PageQuery(
                 0,
                 10,
-                "date",
-                SortDirection.DESC
+                List.of(new PageSort("date", SortDirection.DESC))
         );
 
         PageRequest expectedPageRequest = PageRequest.of(
@@ -144,6 +144,102 @@ class TransactionPersistenceAdapterTest {
         assertThat(result.totalPages()).isEqualTo(1);
         assertThat(result.first()).isTrue();
         assertThat(result.last()).isTrue();
+
+        verify(transactionRepository).findAll(any(Specification.class), eq(expectedPageRequest));
+    }
+
+    @Test
+    @DisplayName("deve listar transações sem ordenação quando page query não tiver sort")
+    void shouldFindAllByFilterWithoutSort() {
+        Long userId = 1L;
+
+        TransactionFilter filter = new TransactionFilter(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        PageQuery pageQuery = new PageQuery(
+                0,
+                10,
+                List.of()
+        );
+
+        PageRequest expectedPageRequest = PageRequest.of(
+                0,
+                10,
+                Sort.unsorted()
+        );
+
+        Transaction transaction = new Transaction();
+        Page<Transaction> page = new PageImpl<>(List.of(transaction), expectedPageRequest, 1);
+
+        when(transactionRepository.findAll(any(Specification.class), eq(expectedPageRequest)))
+                .thenReturn(page);
+
+        PageResult<Transaction> result = transactionPersistenceAdapter.findAllByFilter(
+                userId,
+                filter,
+                pageQuery
+        );
+
+        assertThat(result.content()).containsExactly(transaction);
+        assertThat(result.totalElements()).isEqualTo(1);
+
+        verify(transactionRepository).findAll(any(Specification.class), eq(expectedPageRequest));
+    }
+
+    @Test
+    @DisplayName("deve listar transações preservando múltiplas ordenações")
+    void shouldFindAllByFilterWithMultipleSorts() {
+        Long userId = 1L;
+
+        TransactionFilter filter = new TransactionFilter(
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        PageQuery pageQuery = new PageQuery(
+                0,
+                10,
+                List.of(
+                        new PageSort("date", SortDirection.DESC),
+                        new PageSort("amount", SortDirection.ASC)
+                )
+        );
+
+        PageRequest expectedPageRequest = PageRequest.of(
+                0,
+                10,
+                Sort.by(
+                        Sort.Order.desc("date"),
+                        Sort.Order.asc("amount")
+                )
+        );
+
+        Transaction transaction = new Transaction();
+        Page<Transaction> page = new PageImpl<>(List.of(transaction), expectedPageRequest, 1);
+
+        when(transactionRepository.findAll(any(Specification.class), eq(expectedPageRequest)))
+                .thenReturn(page);
+
+        PageResult<Transaction> result = transactionPersistenceAdapter.findAllByFilter(
+                userId,
+                filter,
+                pageQuery
+        );
+
+        assertThat(result.content()).containsExactly(transaction);
+        assertThat(result.totalElements()).isEqualTo(1);
 
         verify(transactionRepository).findAll(any(Specification.class), eq(expectedPageRequest));
     }

--- a/src/test/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapterTest.java
+++ b/src/test/java/com/financebot/transaction/adapter/out/persistence/TransactionPersistenceAdapterTest.java
@@ -1,5 +1,8 @@
 package com.financebot.transaction.adapter.out.persistence;
 
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.domain.SourceType;
 import com.financebot.transaction.domain.Transaction;
 import com.financebot.transaction.domain.TransactionType;
@@ -14,7 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.time.LocalDate;
@@ -109,20 +112,40 @@ class TransactionPersistenceAdapterTest {
                 "mercado"
         );
 
-        Pageable pageable = PageRequest.of(0, 10);
+        PageQuery pageQuery = new PageQuery(
+                0,
+                10,
+                "date",
+                SortDirection.DESC
+        );
+
+        PageRequest expectedPageRequest = PageRequest.of(
+                0,
+                10,
+                Sort.by(Sort.Direction.DESC, "date")
+        );
 
         Transaction transaction = new Transaction();
-        Page<Transaction> page = new PageImpl<>(List.of(transaction), pageable, 1);
+        Page<Transaction> page = new PageImpl<>(List.of(transaction), expectedPageRequest, 1);
 
-        when(transactionRepository.findAll(any(Specification.class), eq(pageable)))
+        when(transactionRepository.findAll(any(Specification.class), eq(expectedPageRequest)))
                 .thenReturn(page);
 
-        Page<Transaction> result = transactionPersistenceAdapter.findAllByFilter(userId, filter, pageable);
+        PageResult<Transaction> result = transactionPersistenceAdapter.findAllByFilter(
+                userId,
+                filter,
+                pageQuery
+        );
 
-        assertThat(result.getContent()).containsExactly(transaction);
-        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.content()).containsExactly(transaction);
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.totalElements()).isEqualTo(1);
+        assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.first()).isTrue();
+        assertThat(result.last()).isTrue();
 
-        verify(transactionRepository).findAll(any(Specification.class), eq(pageable));
+        verify(transactionRepository).findAll(any(Specification.class), eq(expectedPageRequest));
     }
 
     @Test

--- a/src/test/java/com/financebot/transaction/application/usecase/ListTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/ListTransactionUseCaseTest.java
@@ -2,6 +2,7 @@ package com.financebot.transaction.application.usecase;
 
 import com.financebot.common.pagination.PageQuery;
 import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.PageSort;
 import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
@@ -67,8 +68,7 @@ class ListTransactionUseCaseTest {
         PageQuery pageQuery = new PageQuery(
                 0,
                 10,
-                "date",
-                SortDirection.DESC
+                List.of(new PageSort("date", SortDirection.DESC))
         );
 
         Transaction transaction = new Transaction();
@@ -121,8 +121,7 @@ class ListTransactionUseCaseTest {
         PageQuery pageQuery = new PageQuery(
                 0,
                 10,
-                "date",
-                SortDirection.DESC
+                List.of()
         );
 
         when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);

--- a/src/test/java/com/financebot/transaction/application/usecase/ListTransactionUseCaseTest.java
+++ b/src/test/java/com/financebot/transaction/application/usecase/ListTransactionUseCaseTest.java
@@ -1,5 +1,8 @@
 package com.financebot.transaction.application.usecase;
 
+import com.financebot.common.pagination.PageQuery;
+import com.financebot.common.pagination.PageResult;
+import com.financebot.common.pagination.SortDirection;
 import com.financebot.transaction.application.dto.response.TransactionResponse;
 import com.financebot.transaction.application.port.out.FindTransactionPort;
 import com.financebot.transaction.domain.SourceType;
@@ -15,11 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.security.core.Authentication;
 
 import java.time.LocalDate;
@@ -66,22 +64,42 @@ class ListTransactionUseCaseTest {
                 "mercado"
         );
 
-        Pageable pageable = PageRequest.of(0, 10, Sort.by("date").descending());
+        PageQuery pageQuery = new PageQuery(
+                0,
+                10,
+                "date",
+                SortDirection.DESC
+        );
+
         Transaction transaction = new Transaction();
         TransactionResponse response = mock(TransactionResponse.class);
 
-        Page<Transaction> page = new PageImpl<>(List.of(transaction), pageable, 1);
+        PageResult<Transaction> pageResult = new PageResult<>(
+                List.of(transaction),
+                0,
+                10,
+                1,
+                1,
+                true,
+                true
+        );
 
         when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
-        when(findTransactionPort.findAllByFilter(1L, filter, pageable)).thenReturn(page);
+        when(findTransactionPort.findAllByFilter(1L, filter, pageQuery)).thenReturn(pageResult);
         when(transactionMapper.toResponse(transaction)).thenReturn(response);
 
-        Page<TransactionResponse> result = listTransactionsUseCase.execute(filter, authentication, pageable);
+        PageResult<TransactionResponse> result =
+                listTransactionsUseCase.execute(filter, authentication, pageQuery);
 
-        assertThat(result.getContent()).containsExactly(response);
-        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.content()).containsExactly(response);
+        assertThat(result.totalElements()).isEqualTo(1);
+        assertThat(result.page()).isZero();
+        assertThat(result.size()).isEqualTo(10);
+        assertThat(result.totalPages()).isEqualTo(1);
+        assertThat(result.first()).isTrue();
+        assertThat(result.last()).isTrue();
 
-        verify(findTransactionPort).findAllByFilter(1L, filter, pageable);
+        verify(findTransactionPort).findAllByFilter(1L, filter, pageQuery);
         verify(transactionMapper).toResponse(transaction);
     }
 
@@ -100,15 +118,20 @@ class ListTransactionUseCaseTest {
                 null
         );
 
-        Pageable pageable = PageRequest.of(0, 10);
+        PageQuery pageQuery = new PageQuery(
+                0,
+                10,
+                "date",
+                SortDirection.DESC
+        );
 
         when(authenticatedUserResolver.resolve(authentication)).thenReturn(user);
 
-        assertThatThrownBy(() -> listTransactionsUseCase.execute(filter, authentication, pageable))
+        assertThatThrownBy(() -> listTransactionsUseCase.execute(filter, authentication, pageQuery))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("Start date cannot be after end date");
 
-        verify(findTransactionPort, never()).findAllByFilter(1L, filter, pageable);
+        verify(findTransactionPort, never()).findAllByFilter(1L, filter, pageQuery);
         verifyNoInteractions(transactionMapper);
     }
 


### PR DESCRIPTION
## Objetivo

Remover a dependência direta de `Page` e `Pageable` do Spring Data da camada `application` do módulo de transações, utilizando tipos neutros de paginação e mantendo o contrato público da API sem alteração.

## Alterações realizadas

- Adicionado `PageQuery` como tipo neutro para entrada de paginação na camada de aplicação.
- Adicionado `PageResult<T>` como tipo neutro para resultado paginado.
- Adicionado `PageSort` para representar ordenações sem depender de `Sort.Order` do Spring Data.
- Adicionado `SortDirection` para representar direção de ordenação sem depender de `Sort.Direction`.
- Refatorado `ListTransactionsUseCase` para receber `PageQuery` e retornar `PageResult<TransactionResponse>`.
- Refatorado `FindTransactionPort` para não expor `Page` e `Pageable`.
- Atualizado `TransactionPersistenceAdapter` para converter `PageQuery` em `PageRequest` e `Page` em `PageResult`.
- Atualizado o adapter de persistência para preservar múltiplos sorts e não aplicar sort padrão quando a requisição vier sem ordenação.
- Adicionado `SpringPageMapper` no adapter web para converter `Pageable` em `PageQuery` e `PageResult` em `Page`.
- Mantido o retorno público do endpoint `GET /transactions` como `Page<TransactionResponse>`.
- Atualizados testes de use case, controller e adapter de persistência para o novo contrato de paginação.
- Adicionados testes específicos para o `SpringPageMapper`.
- Atualizado o `CHANGELOG.md` com as mudanças da refatoração.

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [x] Testes
- [x] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [x] Executei `./mvnw clean verify`
- [x] Os testes automatizados passaram
- [x] Rodei análise local no SonarQube quando houve alteração relevante
- [x] O Quality Gate continua aprovado quando houve análise SonarQube
- [x] Não introduzi novas issues críticas de Security ou Reliability
- [x] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [x] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- `./mvnw clean verify` executado com sucesso.
- Suíte executada com 167 testes, 0 falhas e 0 erros.
- SonarQube local executado com Quality Gate aprovado.
- Validado que `transaction/application` não depende mais de `org.springframework.data.domain.Page`.
- Validado que `transaction/application` não depende mais de `org.springframework.data.domain.Pageable`.
- O contrato público do endpoint `GET /transactions` foi mantido como `Page<TransactionResponse>`.
- O mapper de paginação preserva:
  - requisições sem sort;
  - sort ascendente;
  - sort descendente;
  - múltiplos sorts;
  - metadados do `Pageable` original no retorno.

## Trade-offs e decisões técnicas

- O `TransactionController` continua usando `Pageable` e retornando `Page<TransactionResponse>` para manter o contrato público da API sem alteração.
- Os tipos `PageQuery`, `PageResult`, `PageSort` e `SortDirection` foram criados como abstrações neutras para impedir que a camada `application` dependa de tipos do Spring Data.
- O `TransactionPersistenceAdapter` ficou responsável por converter os tipos neutros para `PageRequest`, `Sort` e `Page`, pois esse adapter pertence à infraestrutura/persistência e pode conhecer Spring Data.
- O `SpringPageMapper` foi colocado no adapter web porque conhece tipos do Spring MVC/Spring Data usados na borda HTTP.
- A ordenação padrão não foi forçada quando o `Pageable` vem sem sort, para evitar mudança silenciosa de comportamento no endpoint.
- O suporte a múltiplos sorts foi mantido para preservar o comportamento esperado do `Pageable` recebido pela API.
- O `ListTransactionsUseCase` ainda recebe `Authentication`. A remoção dessa dependência ficou fora do escopo deste PR para manter a issue focada apenas em `Page` e `Pageable`.
- A refatoração foi aplicada apenas ao módulo de transações. A remoção de `Page` e `Pageable` de outros módulos, se necessária, será feita em issues separadas.

## Testes realizados

- [x] `./mvnw clean verify`
- [x] Testes unitários específicos
- [ ] Teste manual
- [x] Análise SonarQube local
- [ ] Não se aplica

## Issue relacionada

Closes #63