### PR TITLE
refactor: alinhar preview e confirmação de transações no Telegram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Alinhado o fluxo de preview, confirmação e persistência de transações via Telegram usando `PendingTelegramTransaction`, garantindo que os dados exibidos ao usuário sejam os mesmos usados na confirmação.
+
+### Tests
+
+- Adicionada cobertura para preview e confirmação de transações comuns e parceladas no bot Telegram.
+- Adicionado teste garantindo que a conta padrão resolvida no preview seja preservada no pending quando encontrada.
+
 ## v1.2.1
 
 ### Changed

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/dto/PendingTelegramTransaction.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/dto/PendingTelegramTransaction.java
@@ -1,0 +1,22 @@
+package com.financebot.telegrambot.dto;
+
+import com.financebot.telegrambot.intent.TelegramIntentType;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+public record PendingTelegramTransaction(
+        TelegramIntentType intentType,
+        BigDecimal amount,
+        String description,
+        LocalDate date,
+        String categoryName,
+        String accountName,
+        Integer totalInstallments,
+        String originalMessage
+) {
+
+    public boolean isInstallment() {
+        return intentType == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE;
+    }
+}

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/formatter/TelegramMessageFormatter.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/formatter/TelegramMessageFormatter.java
@@ -1,6 +1,6 @@
 package com.financebot.telegrambot.formatter;
 
-import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+import com.financebot.telegrambot.dto.PendingTelegramTransaction;
 import com.financebot.telegrambot.intent.TelegramIntentType;
 import org.springframework.stereotype.Component;
 
@@ -99,15 +99,15 @@ public class TelegramMessageFormatter {
     }
 
     public String formatTransactionPreview(
-            ParsedTelegramMessage parsedMessage,
+            PendingTelegramTransaction pendingTransaction,
             String accountName
     ) {
-        String type = parsedMessage.intentType() == TelegramIntentType.CREATE_EXPENSE
+        String type = pendingTransaction.intentType() == TelegramIntentType.CREATE_EXPENSE
                 ? "despesa"
                 : "receita";
 
-        String category = parsedMessage.categoryName() != null
-                ? parsedMessage.categoryName()
+        String category = pendingTransaction.categoryName() != null
+                ? pendingTransaction.categoryName()
                 : "Automática";
 
         return """
@@ -122,20 +122,22 @@ public class TelegramMessageFormatter {
                 Deseja confirmar e salvar?
                 """.formatted(
                 type,
-                formatCurrency(parsedMessage.amount()),
-                parsedMessage.description() != null ? escapeHtml(parsedMessage.description()) : "Não informada",
-                formatDate(parsedMessage.date()),
+                formatCurrency(pendingTransaction.amount()),
+                pendingTransaction.description() != null
+                        ? escapeHtml(pendingTransaction.description())
+                        : "Não informada",
+                formatDate(pendingTransaction.date()),
                 escapeHtml(accountName),
                 escapeHtml(category)
         );
     }
 
     public String formatInstallmentTransactionPreview(
-            ParsedTelegramMessage parsedMessage,
+            PendingTelegramTransaction pendingTransaction,
             String accountName
     ) {
-        String category = parsedMessage.categoryName() != null
-                ? parsedMessage.categoryName()
+        String category = pendingTransaction.categoryName() != null
+                ? pendingTransaction.categoryName()
                 : "Automática";
 
         return """
@@ -150,22 +152,26 @@ public class TelegramMessageFormatter {
                 
                 Deseja confirmar e salvar?
                 """.formatted(
-                formatCurrency(parsedMessage.amount()),
-                parsedMessage.totalInstallments() != null ? parsedMessage.totalInstallments() + "x" : "Não informada",
-                parsedMessage.description() != null ? escapeHtml(parsedMessage.description()) : "Não informada",
-                formatDate(parsedMessage.date()),
+                formatCurrency(pendingTransaction.amount()),
+                pendingTransaction.totalInstallments() != null
+                        ? pendingTransaction.totalInstallments() + "x"
+                        : "Não informada",
+                pendingTransaction.description() != null
+                        ? escapeHtml(pendingTransaction.description())
+                        : "Não informada",
+                formatDate(pendingTransaction.date()),
                 escapeHtml(accountName),
                 escapeHtml(category)
         );
     }
 
     public String formatUpdatedPendingMessage(
-            ParsedTelegramMessage parsedMessage,
+            PendingTelegramTransaction pendingTransaction,
             String accountName
     ) {
-        if (parsedMessage.intentType() == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE) {
-            String category = parsedMessage.categoryName() != null
-                    ? parsedMessage.categoryName()
+        if (pendingTransaction.intentType() == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE) {
+            String category = pendingTransaction.categoryName() != null
+                    ? pendingTransaction.categoryName()
                     : "Automática";
 
             return """
@@ -182,21 +188,25 @@ public class TelegramMessageFormatter {
                     
                     Deseja confirmar e salvar?
                     """.formatted(
-                    formatCurrency(parsedMessage.amount()),
-                    parsedMessage.totalInstallments() != null ? parsedMessage.totalInstallments() + "x" : "Não informada",
-                    parsedMessage.description() != null ? escapeHtml(parsedMessage.description()) : "Não informada",
-                    formatDate(parsedMessage.date()),
+                    formatCurrency(pendingTransaction.amount()),
+                    pendingTransaction.totalInstallments() != null
+                            ? pendingTransaction.totalInstallments() + "x"
+                            : "Não informada",
+                    pendingTransaction.description() != null
+                            ? escapeHtml(pendingTransaction.description())
+                            : "Não informada",
+                    formatDate(pendingTransaction.date()),
                     escapeHtml(accountName),
                     escapeHtml(category)
             );
         }
 
-        String type = parsedMessage.intentType() == TelegramIntentType.CREATE_EXPENSE
+        String type = pendingTransaction.intentType() == TelegramIntentType.CREATE_EXPENSE
                 ? "despesa"
                 : "receita";
 
-        String category = parsedMessage.categoryName() != null
-                ? parsedMessage.categoryName()
+        String category = pendingTransaction.categoryName() != null
+                ? pendingTransaction.categoryName()
                 : "Automática";
 
         return """
@@ -213,9 +223,11 @@ public class TelegramMessageFormatter {
                 Deseja confirmar e salvar?
                 """.formatted(
                 type,
-                formatCurrency(parsedMessage.amount()),
-                parsedMessage.description() != null ? escapeHtml(parsedMessage.description()) : "Não informada",
-                formatDate(parsedMessage.date()),
+                formatCurrency(pendingTransaction.amount()),
+                pendingTransaction.description() != null
+                        ? escapeHtml(pendingTransaction.description())
+                        : "Não informada",
+                formatDate(pendingTransaction.date()),
                 escapeHtml(accountName),
                 escapeHtml(category)
         );

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/mapper/PendingTelegramTransactionMapper.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/mapper/PendingTelegramTransactionMapper.java
@@ -1,0 +1,32 @@
+package com.financebot.telegrambot.mapper;
+
+import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+import com.financebot.telegrambot.dto.PendingTelegramTransaction;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+
+@Component
+public class PendingTelegramTransactionMapper {
+
+    public PendingTelegramTransaction fromParsedMessage(ParsedTelegramMessage parsedMessage) {
+        return new PendingTelegramTransaction(
+                parsedMessage.intentType(),
+                resolveAmount(parsedMessage),
+                parsedMessage.description(),
+                parsedMessage.date(),
+                parsedMessage.categoryName(),
+                parsedMessage.accountName(),
+                parsedMessage.totalInstallments(),
+                parsedMessage.originalMessage()
+        );
+    }
+
+    private BigDecimal resolveAmount(ParsedTelegramMessage parsedMessage) {
+        if (parsedMessage.totalAmount() != null) {
+            return parsedMessage.totalAmount();
+        }
+
+        return parsedMessage.amount();
+    }
+}

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramCommandService.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramCommandService.java
@@ -6,6 +6,7 @@ import com.financebot.telegrambot.dto.request.*;
 import com.financebot.telegrambot.dto.response.*;
 import com.financebot.telegrambot.formatter.TelegramMessageFormatter;
 import com.financebot.telegrambot.intent.TelegramIntentType;
+import com.financebot.telegrambot.mapper.PendingTelegramTransactionMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientResponseException;
@@ -28,8 +29,10 @@ public class TelegramCommandService {
     private final FinanceBotApiClient financeBotApiClient;
     private final TelegramIntentService telegramIntentService;
     private final TelegramPendingConfirmationService telegramPendingConfirmationService;
+    private final TelegramPendingQueryService telegramPendingQueryService;
     private final TelegramQueryContextService telegramQueryContextService;
     private final TelegramMessageFormatter telegramMessageFormatter;
+    private final PendingTelegramTransactionMapper pendingTelegramTransactionMapper;
 
     public String handleMessage(
             String messageText,
@@ -95,12 +98,12 @@ public class TelegramCommandService {
             return handlePendingEdit(telegramId, normalizedMessage);
         }
 
-        ParsedTelegramMessage pending = telegramPendingConfirmationService.getPending(telegramId);
-        if (pending != null
-                && pending.intentType() != null
-                && pending.intentType().name().startsWith("QUERY_INSTALLMENT_")
+        ParsedTelegramMessage pendingQuery = telegramPendingQueryService.getPending(telegramId);
+        if (pendingQuery != null
+                && pendingQuery.intentType() != null
+                && pendingQuery.intentType().name().startsWith("QUERY_INSTALLMENT_")
                 && !normalizedMessage.startsWith("/")) {
-            return handlePendingInstallmentQuerySelection(telegramId, normalizedMessage, pending);
+            return handlePendingInstallmentQuerySelection(telegramId, normalizedMessage, pendingQuery);
         }
 
         ParsedTelegramMessage parsedMessage = telegramIntentService.parse(normalizedMessage);
@@ -177,6 +180,7 @@ public class TelegramCommandService {
         try {
             financeBotApiClient.disconnectTelegram(telegramId);
             telegramPendingConfirmationService.clearPending(telegramId);
+            telegramPendingQueryService.clearPending(telegramId);
 
             return telegramMessageFormatter.formatDisconnectSuccessMessage();
         } catch (RestClientResponseException e) {
@@ -275,37 +279,41 @@ public class TelegramCommandService {
     }
 
     private String handleNaturalLanguageTransactionPreview(Long telegramId, ParsedTelegramMessage parsedMessage) {
-        if (parsedMessage.amount() == null) {
+        if (parsedMessage.amount() == null && parsedMessage.totalAmount() == null) {
             return """
-            Entendi a intenção, mas não consegui identificar o valor.
+        Entendi a intenção, mas não consegui identificar o valor.
+        
+        Exemplos:
+        - gastei 50 no mercado
+        - paguei 120 de gasolina
+        - recebi 1500 de salário
+        """;
+        }
+
+        PendingTelegramTransaction pendingTransaction =
+                pendingTelegramTransactionMapper.fromParsedMessage(parsedMessage);
+
+        ResolvedPreviewAccount resolvedAccount = resolvePreviewAccount(pendingTransaction, telegramId);
+        pendingTransaction = withResolvedAccountName(pendingTransaction, resolvedAccount.persistedName());
+
+        if (pendingTransaction.intentType() == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE) {
+            if (pendingTransaction.totalInstallments() == null || pendingTransaction.totalInstallments() < 2) {
+                return """
+            Entendi a intenção de parcelamento, mas não consegui identificar uma quantidade válida de parcelas.
             
             Exemplos:
-            - gastei 50 no mercado
-            - paguei 120 de gasolina
-            - recebi 1500 de salário
+            - gastei 1200 parcelado em 10x
+            - comprei um celular por 2400 em 12x
+            - gastei 300 no inter parcelado em 3x
             """;
-        }
-
-        String conta = resolvePreviewAccountName(parsedMessage, telegramId);
-
-        if (parsedMessage.intentType() == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE) {
-            if (parsedMessage.totalInstallments() == null || parsedMessage.totalInstallments() < 2) {
-                return """
-                Entendi a intenção de parcelamento, mas não consegui identificar uma quantidade válida de parcelas.
-                
-                Exemplos:
-                - gastei 1200 parcelado em 10x
-                - comprei um celular por 2400 em 12x
-                - gastei 300 no inter parcelado em 3x
-                """;
             }
 
-            telegramPendingConfirmationService.savePending(telegramId, parsedMessage);
-            return telegramMessageFormatter.formatInstallmentTransactionPreview(parsedMessage, conta);
+            telegramPendingConfirmationService.savePending(telegramId, pendingTransaction);
+            return telegramMessageFormatter.formatInstallmentTransactionPreview(pendingTransaction, resolvedAccount.displayName());
         }
 
-        telegramPendingConfirmationService.savePending(telegramId, parsedMessage);
-        return telegramMessageFormatter.formatTransactionPreview(parsedMessage, conta);
+        telegramPendingConfirmationService.savePending(telegramId, pendingTransaction);
+        return telegramMessageFormatter.formatTransactionPreview(pendingTransaction, resolvedAccount.displayName());
     }
 
     private String handleNaturalLanguageQuery(ParsedTelegramMessage parsedMessage, Long telegramId) {
@@ -427,7 +435,7 @@ public class TelegramCommandService {
                         );
                     } catch (RestClientResponseException e) {
                         if (e.getStatusCode().value() == 409 || e.getStatusCode().value() == 403) {
-                            telegramPendingConfirmationService.savePending(telegramId, parsedMessage);
+                            telegramPendingQueryService.savePending(telegramId, parsedMessage);
                             yield telegramMessageFormatter.formatMultipleActiveInstallmentsMessage();
                         }
                         throw e;
@@ -458,7 +466,7 @@ public class TelegramCommandService {
                         );
                     } catch (RestClientResponseException e) {
                         if (e.getStatusCode().value() == 409 || e.getStatusCode().value() == 403) {
-                            telegramPendingConfirmationService.savePending(telegramId, parsedMessage);
+                            telegramPendingQueryService.savePending(telegramId, parsedMessage);
                             yield telegramMessageFormatter.formatMultipleActiveInstallmentsMessage();
                         }
                         throw e;
@@ -477,19 +485,39 @@ public class TelegramCommandService {
         }
     }
 
+    private PendingTelegramTransaction withResolvedAccountName(
+            PendingTelegramTransaction pendingTransaction,
+            String resolvedAccountName
+    ) {
+        if (pendingTransaction.accountName() != null && !pendingTransaction.accountName().isBlank()) {
+            return pendingTransaction;
+        }
+
+        if (resolvedAccountName == null || resolvedAccountName.isBlank()) {
+            return pendingTransaction;
+        }
+
+        return new PendingTelegramTransaction(
+                pendingTransaction.intentType(),
+                pendingTransaction.amount(),
+                pendingTransaction.description(),
+                pendingTransaction.date(),
+                pendingTransaction.categoryName(),
+                resolvedAccountName,
+                pendingTransaction.totalInstallments(),
+                pendingTransaction.originalMessage()
+        );
+    }
+
     private String handleConfirmation(Long telegramId) {
-        ParsedTelegramMessage pending = telegramPendingConfirmationService.getPending(telegramId);
+        PendingTelegramTransaction pending = telegramPendingConfirmationService.getPending(telegramId);
 
         if (pending == null) {
             return "Não há nenhuma operação pendente para confirmar.";
         }
 
-        if (pending.intentType() != null && pending.intentType().name().startsWith("QUERY_INSTALLMENT_")) {
-            return "Me diga qual parcelamento deseja consultar, por exemplo: tv ou computador.";
-        }
-
         try {
-            if (pending.intentType() == TelegramIntentType.CREATE_INSTALLMENT_EXPENSE) {
+            if (pending.isInstallment()) {
                 CreateInstallmentTransactionFromTelegramRequest request =
                         new CreateInstallmentTransactionFromTelegramRequest(
                                 telegramId,
@@ -524,18 +552,22 @@ public class TelegramCommandService {
             return mapDefaultBotErrors(e);
         } catch (Exception e) {
             return """
-                Não foi possível salvar sua transação agora.
-                Você pode tentar confirmar novamente em instantes.
-                """;
+            Não foi possível salvar sua transação agora.
+            Você pode tentar confirmar novamente em instantes.
+            """;
         }
     }
 
     private String handleCancellation(Long telegramId) {
-        if (!telegramPendingConfirmationService.hasPending(telegramId)) {
+        boolean hasPendingConfirmation = telegramPendingConfirmationService.hasPending(telegramId);
+        boolean hasPendingQuery = telegramPendingQueryService.hasPending(telegramId);
+
+        if (!hasPendingConfirmation && !hasPendingQuery) {
             return "Não há nenhuma operação pendente para cancelar.";
         }
 
         telegramPendingConfirmationService.clearPending(telegramId);
+        telegramPendingQueryService.clearPending(telegramId);
 
         return "❌ Operação cancelada com sucesso.";
     }
@@ -565,12 +597,12 @@ public class TelegramCommandService {
                 pending.totalAmount()
         );
 
-        telegramPendingConfirmationService.clearPending(telegramId);
+        telegramPendingQueryService.clearPending(telegramId);
         return handleNaturalLanguageQuery(updated, telegramId);
     }
 
     private String handlePendingEdit(Long telegramId, String messageText) {
-        ParsedTelegramMessage pending = telegramPendingConfirmationService.getPending(telegramId);
+        PendingTelegramTransaction pending = telegramPendingConfirmationService.getPending(telegramId);
 
         if (pending == null) {
             return "Não há nenhuma operação pendente para editar.";
@@ -635,19 +667,15 @@ public class TelegramCommandService {
             return "Entendi que você quer editar a operação, mas não consegui identificar alterações válidas.";
         }
 
-        ParsedTelegramMessage updated = new ParsedTelegramMessage(
+        PendingTelegramTransaction updated = new PendingTelegramTransaction(
                 pending.intentType(),
                 amount,
                 description,
                 date,
-                pending.originalMessage(),
                 categoryName,
                 accountName,
-                pending.startDate(),
-                pending.endDate(),
                 pending.totalInstallments(),
-                pending.installmentQueryTarget(),
-                pending.totalAmount()
+                pending.originalMessage()
         );
 
         telegramPendingConfirmationService.savePending(telegramId, updated);
@@ -655,9 +683,12 @@ public class TelegramCommandService {
         return buildUpdatedPendingMessage(telegramId, updated);
     }
 
-    private String buildUpdatedPendingMessage(Long telegramId, ParsedTelegramMessage parsedMessage) {
-        String conta = resolvePreviewAccountName(parsedMessage, telegramId);
-        return telegramMessageFormatter.formatUpdatedPendingMessage(parsedMessage, conta);
+    private String buildUpdatedPendingMessage(Long telegramId, PendingTelegramTransaction pendingTransaction) {
+        ResolvedPreviewAccount resolvedAccount = resolvePreviewAccount(pendingTransaction, telegramId);
+        return telegramMessageFormatter.formatUpdatedPendingMessage(
+                pendingTransaction,
+                resolvedAccount.displayName()
+        );
     }
 
     private String mapDefaultBotErrors(RestClientResponseException e) {
@@ -976,24 +1007,30 @@ public class TelegramCommandService {
         return capitalizeWords(cleaned);
     }
 
-    private String resolvePreviewAccountName(ParsedTelegramMessage parsedMessage, Long telegramId) {
-        if (parsedMessage.accountName() != null && !parsedMessage.accountName().isBlank()) {
-            return parsedMessage.accountName();
+    private ResolvedPreviewAccount resolvePreviewAccount(PendingTelegramTransaction pendingTransaction, Long telegramId) {
+        if (pendingTransaction.accountName() != null && !pendingTransaction.accountName().isBlank()) {
+            return new ResolvedPreviewAccount(
+                    pendingTransaction.accountName(),
+                    pendingTransaction.accountName()
+            );
         }
 
         try {
             TelegramDefaultAccountResponse response = financeBotApiClient.getDefaultAccount(telegramId);
 
             if (response != null && response.accountName() != null && !response.accountName().isBlank()) {
-                return response.accountName();
+                return new ResolvedPreviewAccount(
+                        response.accountName(),
+                        response.accountName()
+                );
             }
         } catch (RestClientResponseException e) {
-            return "conta padrão";
+            return new ResolvedPreviewAccount("conta padrão", null);
         } catch (Exception e) {
-            return "conta padrão";
+            return new ResolvedPreviewAccount("conta padrão", null);
         }
 
-        return "conta padrão";
+        return new ResolvedPreviewAccount("conta padrão", null);
     }
 
     private boolean containsAmountEditHint(String lower) {
@@ -1020,6 +1057,12 @@ public class TelegramCommandService {
 
     private boolean containsAccountEditHint(String lower) {
         return lower.contains("conta");
+    }
+
+    private record ResolvedPreviewAccount(
+            String displayName,
+            String persistedName
+    ) {
     }
 
     private String trimAtNextEditHint(String text) {

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramPendingConfirmationService.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramPendingConfirmationService.java
@@ -1,6 +1,6 @@
 package com.financebot.telegrambot.service;
 
-import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+import com.financebot.telegrambot.dto.PendingTelegramTransaction;
 import org.springframework.stereotype.Service;
 
 import java.util.Map;
@@ -9,13 +9,13 @@ import java.util.concurrent.ConcurrentHashMap;
 @Service
 public class TelegramPendingConfirmationService {
 
-    private final Map<Long, ParsedTelegramMessage> pendingMessages = new ConcurrentHashMap<>();
+    private final Map<Long, PendingTelegramTransaction> pendingMessages = new ConcurrentHashMap<>();
 
-    public void savePending(Long telegramId, ParsedTelegramMessage parsedMessage) {
-        pendingMessages.put(telegramId, parsedMessage);
+    public void savePending(Long telegramId, PendingTelegramTransaction pendingTransaction) {
+        pendingMessages.put(telegramId, pendingTransaction);
     }
 
-    public ParsedTelegramMessage getPending(Long telegramId) {
+    public PendingTelegramTransaction getPending(Long telegramId) {
         return pendingMessages.get(telegramId);
     }
 

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramPendingQueryService.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramPendingQueryService.java
@@ -1,0 +1,29 @@
+package com.financebot.telegrambot.service;
+
+import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class TelegramPendingQueryService {
+
+    private final Map<Long, ParsedTelegramMessage> pendingQueries = new ConcurrentHashMap<>();
+
+    public void savePending(Long telegramId, ParsedTelegramMessage parsedMessage) {
+        pendingQueries.put(telegramId, parsedMessage);
+    }
+
+    public ParsedTelegramMessage getPending(Long telegramId) {
+        return pendingQueries.get(telegramId);
+    }
+
+    public void clearPending(Long telegramId) {
+        pendingQueries.remove(telegramId);
+    }
+
+    public boolean hasPending(Long telegramId) {
+        return pendingQueries.containsKey(telegramId);
+    }
+}

--- a/financebot-telegram-bot/src/test/java/com/financebot/telegrambot/service/TelegramCommandServiceTest.java
+++ b/financebot-telegram-bot/src/test/java/com/financebot/telegrambot/service/TelegramCommandServiceTest.java
@@ -2,10 +2,15 @@ package com.financebot.telegrambot.service;
 
 import com.financebot.telegrambot.client.FinanceBotApiClient;
 import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+import com.financebot.telegrambot.dto.PendingTelegramTransaction;
+import com.financebot.telegrambot.dto.request.CreateInstallmentTransactionFromTelegramRequest;
+import com.financebot.telegrambot.dto.request.CreateTransactionFromTelegramRequest;
 import com.financebot.telegrambot.dto.request.InstallmentPurchaseCapacityRequest;
 import com.financebot.telegrambot.dto.response.InstallmentPurchaseCapacityResponse;
+import com.financebot.telegrambot.dto.response.TelegramDefaultAccountResponse;
 import com.financebot.telegrambot.formatter.TelegramMessageFormatter;
 import com.financebot.telegrambot.intent.TelegramIntentType;
+import com.financebot.telegrambot.mapper.PendingTelegramTransactionMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -39,6 +45,9 @@ class TelegramCommandServiceTest {
     private TelegramPendingConfirmationService telegramPendingConfirmationService;
 
     @Mock
+    private TelegramPendingQueryService telegramPendingQueryService;
+
+    @Mock
     private TelegramQueryContextService telegramQueryContextService;
 
     private TelegramCommandService telegramCommandService;
@@ -49,8 +58,10 @@ class TelegramCommandServiceTest {
                 financeBotApiClient,
                 telegramIntentService,
                 telegramPendingConfirmationService,
+                telegramPendingQueryService,
                 telegramQueryContextService,
-                new TelegramMessageFormatter()
+                new TelegramMessageFormatter(),
+                new PendingTelegramTransactionMapper()
         );
     }
 
@@ -73,7 +84,8 @@ class TelegramCommandServiceTest {
         );
 
         when(telegramIntentService.parse(any())).thenReturn(parsedMessage);
-        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage))).thenReturn(parsedMessage);
+        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage)))
+                .thenReturn(parsedMessage);
         when(financeBotApiClient.getInstallmentPurchaseCapacity(any()))
                 .thenReturn(new InstallmentPurchaseCapacityResponse(
                         new BigDecimal("2400"),
@@ -126,7 +138,8 @@ class TelegramCommandServiceTest {
         );
 
         when(telegramIntentService.parse(any())).thenReturn(parsedMessage);
-        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage))).thenReturn(parsedMessage);
+        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage)))
+                .thenReturn(parsedMessage);
         when(financeBotApiClient.getInstallmentPurchaseCapacity(any()))
                 .thenThrow(HttpClientErrorException.create(
                         HttpStatus.BAD_REQUEST,
@@ -144,5 +157,229 @@ class TelegramCommandServiceTest {
         );
 
         assertThat(result).contains("solicitação está inválida");
+    }
+
+    @Test
+    @DisplayName("deve gerar preview de despesa e salvar PendingTelegramTransaction")
+    void shouldGenerateExpensePreviewAndSavePendingTransaction() {
+        ParsedTelegramMessage parsedMessage = new ParsedTelegramMessage(
+                TelegramIntentType.CREATE_EXPENSE,
+                new BigDecimal("50.00"),
+                "mercado",
+                LocalDate.of(2026, 6, 1),
+                "gastei 50 no mercado pelo nubank",
+                "Mercado",
+                "Nubank",
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(telegramIntentService.parse(any())).thenReturn(parsedMessage);
+        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage)))
+                .thenReturn(parsedMessage);
+
+        String result = telegramCommandService.handleMessage(
+                "gastei 50 no mercado pelo nubank",
+                123L,
+                "bryan",
+                "Bryan"
+        );
+
+        ArgumentCaptor<PendingTelegramTransaction> pendingCaptor =
+                ArgumentCaptor.forClass(PendingTelegramTransaction.class);
+
+        verify(telegramPendingConfirmationService).savePending(eq(123L), pendingCaptor.capture());
+        verify(telegramPendingQueryService, never()).savePending(any(), any());
+
+        PendingTelegramTransaction pending = pendingCaptor.getValue();
+
+        assertThat(pending.intentType()).isEqualTo(TelegramIntentType.CREATE_EXPENSE);
+        assertThat(pending.amount()).isEqualByComparingTo("50.00");
+        assertThat(pending.description()).isEqualTo("mercado");
+        assertThat(pending.date()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(pending.categoryName()).isEqualTo("Mercado");
+        assertThat(pending.accountName()).isEqualTo("Nubank");
+
+        assertThat(result).contains("Entendi esta despesa");
+        assertThat(result).contains("Mercado");
+        assertThat(result).contains("Nubank");
+    }
+
+    @Test
+    @DisplayName("deve confirmar despesa usando dados do PendingTelegramTransaction")
+    void shouldConfirmExpenseUsingPendingTransactionData() {
+        PendingTelegramTransaction pending = new PendingTelegramTransaction(
+                TelegramIntentType.CREATE_EXPENSE,
+                new BigDecimal("50.00"),
+                "mercado",
+                LocalDate.of(2026, 6, 1),
+                "Mercado",
+                "Nubank",
+                null,
+                "gastei 50 no mercado pelo nubank"
+        );
+
+        when(telegramPendingConfirmationService.getPending(123L)).thenReturn(pending);
+
+        String result = telegramCommandService.handleMessage(
+                "confirmar",
+                123L,
+                "bryan",
+                "Bryan"
+        );
+
+        ArgumentCaptor<CreateTransactionFromTelegramRequest> requestCaptor =
+                ArgumentCaptor.forClass(CreateTransactionFromTelegramRequest.class);
+
+        verify(financeBotApiClient).createTransaction(requestCaptor.capture());
+        verify(telegramPendingConfirmationService).clearPending(123L);
+
+        CreateTransactionFromTelegramRequest request = requestCaptor.getValue();
+
+        assertThat(request.telegramId()).isEqualTo(123L);
+        assertThat(request.type()).isEqualTo("EXPENSE");
+        assertThat(request.amount()).isEqualByComparingTo("50.00");
+        assertThat(request.description()).isEqualTo("mercado");
+        assertThat(request.date()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(request.categoryName()).isEqualTo("Mercado");
+        assertThat(request.accountName()).isEqualTo("Nubank");
+
+        assertThat(result).contains("Transação registrada com sucesso");
+    }
+
+    @Test
+    @DisplayName("deve gerar preview de parcelamento e salvar PendingTelegramTransaction")
+    void shouldGenerateInstallmentPreviewAndSavePendingTransaction() {
+        ParsedTelegramMessage parsedMessage = new ParsedTelegramMessage(
+                TelegramIntentType.CREATE_INSTALLMENT_EXPENSE,
+                new BigDecimal("1200.00"),
+                "notebook",
+                LocalDate.of(2026, 6, 1),
+                "comprei notebook de 1200 em 12x no nubank",
+                "Eletrônicos",
+                "Nubank",
+                null,
+                null,
+                12,
+                null,
+                null
+        );
+
+        when(telegramIntentService.parse(any())).thenReturn(parsedMessage);
+        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage)))
+                .thenReturn(parsedMessage);
+
+        String result = telegramCommandService.handleMessage(
+                "comprei notebook de 1200 em 12x no nubank",
+                123L,
+                "bryan",
+                "Bryan"
+        );
+
+        ArgumentCaptor<PendingTelegramTransaction> pendingCaptor =
+                ArgumentCaptor.forClass(PendingTelegramTransaction.class);
+
+        verify(telegramPendingConfirmationService).savePending(eq(123L), pendingCaptor.capture());
+
+        PendingTelegramTransaction pending = pendingCaptor.getValue();
+
+        assertThat(pending.intentType()).isEqualTo(TelegramIntentType.CREATE_INSTALLMENT_EXPENSE);
+        assertThat(pending.amount()).isEqualByComparingTo("1200.00");
+        assertThat(pending.description()).isEqualTo("notebook");
+        assertThat(pending.date()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(pending.categoryName()).isEqualTo("Eletrônicos");
+        assertThat(pending.accountName()).isEqualTo("Nubank");
+        assertThat(pending.totalInstallments()).isEqualTo(12);
+
+        assertThat(result).contains("Entendi este parcelamento");
+        assertThat(result).contains("12x");
+        assertThat(result).contains("Nubank");
+    }
+
+    @Test
+    @DisplayName("deve confirmar parcelamento usando dados do PendingTelegramTransaction")
+    void shouldConfirmInstallmentUsingPendingTransactionData() {
+        PendingTelegramTransaction pending = new PendingTelegramTransaction(
+                TelegramIntentType.CREATE_INSTALLMENT_EXPENSE,
+                new BigDecimal("1200.00"),
+                "notebook",
+                LocalDate.of(2026, 6, 1),
+                "Eletrônicos",
+                "Nubank",
+                12,
+                "comprei notebook de 1200 em 12x no nubank"
+        );
+
+        when(telegramPendingConfirmationService.getPending(123L)).thenReturn(pending);
+
+        String result = telegramCommandService.handleMessage(
+                "sim",
+                123L,
+                "bryan",
+                "Bryan"
+        );
+
+        ArgumentCaptor<CreateInstallmentTransactionFromTelegramRequest> requestCaptor =
+                ArgumentCaptor.forClass(CreateInstallmentTransactionFromTelegramRequest.class);
+
+        verify(financeBotApiClient).createInstallmentTransaction(requestCaptor.capture());
+        verify(telegramPendingConfirmationService).clearPending(123L);
+
+        CreateInstallmentTransactionFromTelegramRequest request = requestCaptor.getValue();
+
+        assertThat(request.telegramId()).isEqualTo(123L);
+        assertThat(request.totalAmount()).isEqualByComparingTo("1200.00");
+        assertThat(request.description()).isEqualTo("notebook");
+        assertThat(request.firstInstallmentDate()).isEqualTo(LocalDate.of(2026, 6, 1));
+        assertThat(request.categoryName()).isEqualTo("Eletrônicos");
+        assertThat(request.accountName()).isEqualTo("Nubank");
+        assertThat(request.totalInstallments()).isEqualTo(12);
+
+        assertThat(result).contains("Parcelamento registrado com sucesso");
+    }
+
+    @Test
+    @DisplayName("deve salvar conta padrao resolvida no PendingTelegramTransaction")
+    void shouldSaveResolvedDefaultAccountInPendingTransaction() {
+        ParsedTelegramMessage parsedMessage = new ParsedTelegramMessage(
+                TelegramIntentType.CREATE_EXPENSE,
+                new BigDecimal("80.00"),
+                "gasolina",
+                LocalDate.of(2026, 6, 1),
+                "paguei 80 de gasolina",
+                "Combustível",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+
+        when(telegramIntentService.parse(any())).thenReturn(parsedMessage);
+        when(telegramQueryContextService.applyQueryContext(eq(123L), any(), eq(parsedMessage)))
+                .thenReturn(parsedMessage);
+        when(financeBotApiClient.getDefaultAccount(123L))
+                .thenReturn(new TelegramDefaultAccountResponse(10L, "Carteira"));
+
+        String result = telegramCommandService.handleMessage(
+                "paguei 80 de gasolina",
+                123L,
+                "bryan",
+                "Bryan"
+        );
+
+        ArgumentCaptor<PendingTelegramTransaction> pendingCaptor =
+                ArgumentCaptor.forClass(PendingTelegramTransaction.class);
+
+        verify(telegramPendingConfirmationService).savePending(eq(123L), pendingCaptor.capture());
+
+        PendingTelegramTransaction pending = pendingCaptor.getValue();
+
+        assertThat(pending.accountName()).isEqualTo("Carteira");
+        assertThat(result).contains("Carteira");
     }
 }


### PR DESCRIPTION
## Objetivo

Alinhar o fluxo de preview, confirmação e persistência de transações via Telegram, garantindo que os dados exibidos ao usuário antes da confirmação sejam os mesmos usados para montar o request enviado ao backend.

## Alterações realizadas

- Criado `PendingTelegramTransaction` para representar transações aguardando confirmação do usuário.
- Criado `PendingTelegramTransactionMapper` para converter `ParsedTelegramMessage` em uma operação confirmável.
- Ajustado o fluxo de preview para usar `PendingTelegramTransaction`.
- Ajustado o fluxo de confirmação para montar os requests do backend a partir do mesmo pending usado no preview.
- Separado o controle de pendências:
  - `TelegramPendingConfirmationService` guarda transações pendentes de confirmação.
  - `TelegramPendingQueryService` guarda consultas pendentes que precisam de complemento do usuário.
- Ajustado `TelegramMessageFormatter` para formatar previews com base em `PendingTelegramTransaction`.
- Garantido que a conta padrão resolvida no preview seja preservada no pending quando encontrada.
- Atualizados testes do `TelegramCommandService`.
- Atualizado `CHANGELOG.md`.

## Trade-offs

- O `TelegramCommandService` continua grande e com muitas responsabilidades. A refatoração completa dele foi deixada para uma próxima issue para manter este PR com escopo pequeno e seguro.
- As pendências continuam sendo mantidas em memória, seguindo o comportamento atual do bot. Persistência com Redis será tratada em evolução futura.
- A separação entre pending de confirmação e pending de query adiciona mais uma classe de serviço, mas reduz acoplamento e evita misturar fluxos diferentes.

## Tipo de mudança

- [ ] Feature
- [ ] Bugfix
- [x] Refatoração
- [x] Testes
- [x] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [x] Executei `./mvnw clean verify`
- [x] Os testes automatizados passaram
- [ ] Rodei análise local no SonarQube quando houve alteração relevante
- [ ] O Quality Gate continua aprovado quando houve análise SonarQube
- [x] Não introduzi novas issues críticas de Security ou Reliability
- [x] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [x] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- `./mvnw clean verify` executado com sucesso.
- Testes do `TelegramCommandService` atualizados.
- `CHANGELOG.md` atualizado.
- Review técnico realizado sem bug funcional identificado.

## Testes realizados

- [x] `./mvnw clean verify`
- [x] Testes unitários específicos
- [ ] Teste manual
- [ ] Análise SonarQube local
- [ ] Não se aplica

### Cenários cobertos pelos testes

- Consulta de viabilidade de compra parcelada.
- Preview de despesa comum salvando `PendingTelegramTransaction`.
- Confirmação de despesa comum usando os dados do pending.
- Preview de parcelamento salvando `PendingTelegramTransaction`.
- Confirmação de parcelamento usando os dados do pending.
- Conta padrão resolvida sendo salva no pending quando encontrada.

## Issue relacionada

Closes #73