### PR TITLE
fix: avoid failing Telegram queries when context save fails

### DIFF
--- a/compose.local.yml
+++ b/compose.local.yml
@@ -1,34 +1,31 @@
 services:
-  financebot:
-    build: .
-    container_name: financebot-backend
-
-    ports:
-      - "8080:8080"
-
-    env_file:
-      - .env
-
+  postgres:
+    image: postgres:17
+    container_name: financebot-postgres-local
     environment:
-      DB_URL: ${DB_URL}
-      DB_USER: ${DB_USER}
-      DB_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:5432"
+    volumes:
+      - financebot_postgres_data:/var/lib/postgresql/data
 
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
+  redis:
+    image: redis:7
+    container_name: financebot-redis-local
+    ports:
+      - "${REDIS_PORT}:6379"
 
-      RABBITMQ_HOST: ${RABBITMQ_HOST}
-      RABBITMQ_PORT: ${RABBITMQ_PORT}
-      RABBITMQ_USER: ${RABBITMQ_USER}
-      RABBITMQ_PASSWORD: ${RABBITMQ_PASSWORD}
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: financebot-rabbitmq-local
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    ports:
+      - "${RABBITMQ_PORT}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT}:15672"
 
-      JWT_SECRET: ${JWT_SECRET}
-      JWT_EXPIRATION: ${JWT_EXPIRATION}
-
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS}
-
-    networks:
-      - backend-network
-
-networks:
-  backend-network:
+volumes:
+  financebot_postgres_data:

--- a/financebot-telegram-bot/compose.local.yml
+++ b/financebot-telegram-bot/compose.local.yml
@@ -1,25 +1,31 @@
 services:
-  financebot-telegram-bot:
-    build: .
-    container_name: financebot-telegram-bot
-
-    ports:
-      - "8081:8081"
-
-    env_file:
-      - .env
-
+  postgres:
+    image: postgres:17
+    container_name: financebot-postgres-local
     environment:
-      TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN}
-      FINANCEBOT_API_URL: ${FINANCEBOT_API_URL}
-      REDIS_HOST: ${REDIS_HOST}
-      REDIS_PORT: ${REDIS_PORT}
-      TELEGRAM_STATE_STORE: ${TELEGRAM_STATE_STORE}
-      TELEGRAM_CONVERSATION_CONTEXT_TTL: ${TELEGRAM_CONVERSATION_CONTEXT_TTL}
-      TELEGRAM_QUERY_CONTEXT_TTL: ${TELEGRAM_QUERY_CONTEXT_TTL}
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:5432"
+    volumes:
+      - financebot_postgres_data:/var/lib/postgresql/data
 
-    networks:
-      - backend-network
+  redis:
+    image: redis:7
+    container_name: financebot-redis-local
+    ports:
+      - "${REDIS_PORT}:6379"
 
-networks:
-  backend-network:
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: financebot-rabbitmq-local
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD}
+    ports:
+      - "${RABBITMQ_PORT}:5672"
+      - "${RABBITMQ_MANAGEMENT_PORT}:15672"
+
+volumes:
+  financebot_postgres_data:

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/handler/TelegramFinancialQueryHandler.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/handler/TelegramFinancialQueryHandler.java
@@ -16,9 +16,11 @@ import com.financebot.telegrambot.service.TelegramPendingQueryService;
 import com.financebot.telegrambot.service.TelegramQueryContextService;
 import com.financebot.telegrambot.support.TelegramBotErrorMapper;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClientResponseException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class TelegramFinancialQueryHandler {
@@ -34,18 +36,26 @@ public class TelegramFinancialQueryHandler {
         try {
             String resultMessage = switch (parsedMessage.intentType()) {
                 case QUERY_MONTH_EXPENSE_TOTAL -> {
-                    MonthlyAmountSummaryResponse response = financeBotApiClient.getCurrentMonthExpenseSummary(telegramId);
+                    MonthlyAmountSummaryResponse response =
+                            financeBotApiClient.getCurrentMonthExpenseSummary(telegramId);
+
                     yield telegramMessageFormatter.formatMonthExpenseSummary(response.totalAmount());
                 }
+
                 case QUERY_MONTH_INCOME_TOTAL -> {
-                    MonthlyAmountSummaryResponse response = financeBotApiClient.getCurrentMonthIncomeSummary(telegramId);
+                    MonthlyAmountSummaryResponse response =
+                            financeBotApiClient.getCurrentMonthIncomeSummary(telegramId);
+
                     yield telegramMessageFormatter.formatMonthIncomeSummary(response.totalAmount());
                 }
+
                 case QUERY_MONTH_ANALYSIS -> telegramBasicCommandHandler.handleAnalysis(telegramId);
 
                 case QUERY_TRANSACTION_TOTAL -> {
-                    String type = parsedMessage.originalMessage().toLowerCase().contains("recebi")
-                            || parsedMessage.originalMessage().toLowerCase().contains("entrou")
+                    String originalMessage = parsedMessage.originalMessage().toLowerCase();
+
+                    String type = originalMessage.contains("recebi")
+                            || originalMessage.contains("entrou")
                             ? "INCOME"
                             : "EXPENSE";
 
@@ -63,9 +73,11 @@ public class TelegramFinancialQueryHandler {
                     String label = "EXPENSE".equals(type) ? "gasto" : "recebido";
 
                     StringBuilder complemento = new StringBuilder();
+
                     if (response.categoryName() != null) {
                         complemento.append(" em ").append(response.categoryName());
                     }
+
                     if (response.accountName() != null) {
                         complemento.append(" na conta ").append(response.accountName());
                     }
@@ -113,7 +125,8 @@ public class TelegramFinancialQueryHandler {
                 }
 
                 case QUERY_ACTIVE_INSTALLMENTS -> {
-                    TelegramActiveInstallmentsResponse response = financeBotApiClient.getActiveInstallments(telegramId);
+                    TelegramActiveInstallmentsResponse response =
+                            financeBotApiClient.getActiveInstallments(telegramId);
 
                     yield telegramMessageFormatter.formatActiveInstallmentsMessage(
                             response.activeInstallmentGroupCount()
@@ -127,12 +140,36 @@ public class TelegramFinancialQueryHandler {
                 default -> "Não consegui interpretar sua consulta.";
             };
 
-            telegramQueryContextService.saveQueryContext(telegramId, parsedMessage);
+            saveQueryContextWithoutBlockingResponse(telegramId, parsedMessage);
+
             return resultMessage;
         } catch (RestClientResponseException e) {
             return telegramBotErrorMapper.mapDefaultBotErrors(e);
         } catch (Exception e) {
+            log.error(
+                    "Erro ao processar consulta financeira. intentType={}, telegramId={}, categoryName={}, accountName={}, startDate={}, endDate={}",
+                    parsedMessage != null ? parsedMessage.intentType() : null,
+                    telegramId,
+                    parsedMessage != null ? parsedMessage.categoryName() : null,
+                    parsedMessage != null ? parsedMessage.accountName() : null,
+                    parsedMessage != null ? parsedMessage.startDate() : null,
+                    parsedMessage != null ? parsedMessage.endDate() : null,
+                    e
+            );
+
             return "Não foi possível consultar essas informações agora.";
+        }
+    }
+
+    private void saveQueryContextWithoutBlockingResponse( Long telegramId, ParsedTelegramMessage parsedMessage) {
+        try {
+            telegramQueryContextService.saveQueryContext(telegramId, parsedMessage);
+        } catch (Exception e) {
+            log.warn(
+                    "Não foi possível salvar contexto da consulta, mas a resposta será enviada normalmente. telegramId={}",
+                    telegramId,
+                    e
+            );
         }
     }
 


### PR DESCRIPTION
## Objetivo

Corrigir uma falha nas consultas financeiras feitas pelo Telegram, evitando que a resposta da consulta seja bloqueada quando ocorrer erro ao salvar o contexto temporário da conversa.

## Alterações realizadas

- Isolado o salvamento do contexto da consulta em um `try/catch` próprio.
- Garantido que a resposta da consulta financeira seja enviada normalmente mesmo se o contexto não puder ser salvo.
- Adicionados logs para facilitar o diagnóstico de erros em consultas financeiras.
- Ajustado o `compose.local.yml` para subir apenas os serviços de infraestrutura local, como PostgreSQL, Redis e RabbitMQ.

## Tipo de mudança

- [ ] Feature
- [x] Bugfix
- [ ] Refatoração
- [ ] Testes
- [ ] Documentação
- [x] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [ ] Executei `./mvnw clean verify`
- [x] Os testes automatizados passaram
- [ ] Rodei análise local no SonarQube quando houve alteração relevante
- [ ] O Quality Gate continua aprovado quando houve análise SonarQube
- [ ] Não introduzi novas issues críticas de Security ou Reliability
- [ ] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [ ] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- Executado `./mvnw test` no módulo `financebot-telegram-bot`.
- Resultado dos testes:
  - `Tests run: 90`
  - `Failures: 0`
  - `Errors: 0`
  - `Skipped: 0`
  - `BUILD SUCCESS`
- Teste manual realizado no Telegram:
  - Consulta: `quanto gastei com saúde esse mês?`
  - Resultado: bot retornou corretamente o total de `R$ 348,00`.
- Validado que a consulta deixou de retornar a mensagem genérica: `Não foi possível consultar essas informações agora.`

## Testes realizados

- [ ] `./mvnw clean verify`
- [x] Testes unitários específicos
- [x] Teste manual
- [ ] Análise SonarQube local
- [ ] Não se aplica

## Issue relacionada

Closes #