### PR TITLE
release: merge Telegram parser improvements into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- Adicionado suporte a novos aliases de categorias e contas no vocabulário de linguagem natural do bot Telegram.
+- Adicionado suporte a novas expressões de período nas consultas do Telegram, incluindo semana atual e últimos 30 dias.
+- Adicionado suporte a novas variações de perguntas sobre término de parcelamentos.
+
+### Changed
+
+- Melhorada a detecção de intenções de despesa e receita em mensagens naturais do Telegram.
+- Melhorada a limpeza da descrição de transações interpretadas pelo Telegram, evitando sobras como preposições após remoção de valores.
+- Centralizados termos e padrões de limpeza do parser em constantes para facilitar manutenção.
+
 ## v1.4.0
 
 ### Added

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramDateRangeResolver.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramDateRangeResolver.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.util.regex.Pattern;
 
 @Component
 public class TelegramDateRangeResolver {
@@ -14,8 +15,11 @@ public class TelegramDateRangeResolver {
         LocalDate today = LocalDate.now();
 
         if (normalizedText == null || normalizedText.isBlank()) {
-            YearMonth currentMonth = YearMonth.from(today);
-            return new ParsedDateRange(currentMonth.atDay(1), currentMonth.atEndOfMonth());
+            return currentMonthRange(today);
+        }
+
+        if (containsLast30Days(normalizedText)) {
+            return new ParsedDateRange(today.minusDays(29), today);
         }
 
         if (containsLast7Days(normalizedText)) {
@@ -39,35 +43,51 @@ public class TelegramDateRangeResolver {
             return new ParsedDateRange(startOfLastWeek, endOfLastWeek);
         }
 
+        if (containsCurrentWeek(normalizedText)) {
+            LocalDate startOfCurrentWeek = today.with(DayOfWeek.MONDAY);
+            return new ParsedDateRange(startOfCurrentWeek, today);
+        }
+
         if (containsLastMonth(normalizedText)) {
             YearMonth lastMonth = YearMonth.from(today).minusMonths(1);
             return new ParsedDateRange(lastMonth.atDay(1), lastMonth.atEndOfMonth());
         }
 
         if (containsCurrentMonth(normalizedText)) {
-            YearMonth currentMonth = YearMonth.from(today);
-            return new ParsedDateRange(currentMonth.atDay(1), currentMonth.atEndOfMonth());
+            return currentMonthRange(today);
         }
 
-        YearMonth currentMonth = YearMonth.from(today);
-        return new ParsedDateRange(currentMonth.atDay(1), currentMonth.atEndOfMonth());
+        return currentMonthRange(today);
     }
 
     public boolean hasExplicitRangeHint(String normalizedText) {
-        return containsLast7Days(normalizedText)
+        if (normalizedText == null || normalizedText.isBlank()) {
+            return false;
+        }
+
+        return containsLast30Days(normalizedText)
+                || containsLast7Days(normalizedText)
                 || containsYesterday(normalizedText)
                 || containsToday(normalizedText)
                 || containsLastWeek(normalizedText)
+                || containsCurrentWeek(normalizedText)
                 || containsLastMonth(normalizedText)
                 || containsCurrentMonth(normalizedText);
     }
 
+    private ParsedDateRange currentMonthRange(LocalDate today) {
+        YearMonth currentMonth = YearMonth.from(today);
+        return new ParsedDateRange(currentMonth.atDay(1), currentMonth.atEndOfMonth());
+    }
+
     private boolean containsToday(String text) {
-        return text.contains("hoje");
+        return containsWord(text, "hoje")
+                || containsWord(text, "hj");
     }
 
     private boolean containsYesterday(String text) {
-        return text.contains("ontem");
+        return containsWord(text, "ontem")
+                || containsWord(text, "ont");
     }
 
     private boolean containsCurrentMonth(String text) {
@@ -75,6 +95,7 @@ public class TelegramDateRangeResolver {
                 || text.contains("este mes")
                 || text.contains("no mes")
                 || text.contains("nesse mes")
+                || text.contains("neste mes")
                 || text.contains("mes atual");
     }
 
@@ -90,9 +111,24 @@ public class TelegramDateRangeResolver {
                 || text.contains("semana anterior");
     }
 
+    private boolean containsCurrentWeek(String text) {
+        return text.contains("essa semana")
+                || text.contains("esta semana")
+                || text.contains("semana atual");
+    }
+
     private boolean containsLast7Days(String text) {
         return text.contains("ultimos 7 dias")
-                || text.contains("últimos 7 dias")
                 || text.contains("7 dias");
+    }
+
+    private boolean containsLast30Days(String text) {
+        return text.contains("ultimos 30 dias")
+                || text.contains("30 dias");
+    }
+
+    private boolean containsWord(String text, String word) {
+        Pattern pattern = Pattern.compile("(^|\\b)" + Pattern.quote(word) + "(\\b|$)");
+        return pattern.matcher(text).find();
     }
 }

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramIntentService.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramIntentService.java
@@ -1,145 +1,122 @@
-package com.financebot.telegrambot.service;
+    package com.financebot.telegrambot.service;
 
-import com.financebot.telegrambot.dto.ParsedDateRange;
-import com.financebot.telegrambot.dto.ParsedTelegramMessage;
-import com.financebot.telegrambot.intent.TelegramIntentType;
-import org.springframework.stereotype.Service;
+    import com.financebot.telegrambot.dto.ParsedDateRange;
+    import com.financebot.telegrambot.dto.ParsedTelegramMessage;
+    import com.financebot.telegrambot.intent.TelegramIntentType;
+    import org.springframework.stereotype.Service;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+    import java.math.BigDecimal;
+    import java.time.LocalDate;
+    import java.util.regex.Matcher;
+    import java.util.regex.Pattern;
 
-@Service
-public class TelegramIntentService {
+    @Service
+    public class TelegramIntentService {
 
-    private final TelegramDateRangeResolver telegramDateRangeResolver;
-    private final TelegramNaturalLanguageVocabulary telegramNaturalLanguageVocabulary;
+        private static final String DATE_NOISE_WORDS =
+                "ultimos 30 dias|ultimos 7 dias|mes passado|semana passada|essa semana|esta semana|esse mes|este mes|nesse mes|neste mes|mes atual|hoje|hj|ontem|ont|amanha|mes|30 dias";
 
-    public TelegramIntentService(
-            TelegramDateRangeResolver telegramDateRangeResolver,
-            TelegramNaturalLanguageVocabulary telegramNaturalLanguageVocabulary
-    ) {
-        this.telegramDateRangeResolver = telegramDateRangeResolver;
-        this.telegramNaturalLanguageVocabulary = telegramNaturalLanguageVocabulary;
-    }
+        private static final String ACCOUNT_BOUNDARY_WORDS =
+                "ultimos 30 dias|ultimos 7 dias|mes passado|semana passada|essa semana|esta semana|esse mes|este mes|nesse mes|neste mes|hoje|hj|ontem|ont|amanha|e";
 
-    private static final Pattern AMOUNT_PATTERN = Pattern.compile("(\\d+[\\.,]?\\d{0,2})");
-    private static final Pattern EXPLICIT_ACCOUNT_PATTERN = Pattern.compile(
-            "\\b(?:conta|cartao)\\s+(?:da|do|de)?\\s*([a-zA-Z0-9\\s]+?)(?=\\b(?:hoje|ontem|amanha|esse mes|este mes|mes passado|semana passada|ultimos 7 dias|e|,|\\?|$))"
-    );
+        private static final String TRANSACTION_NOISE_WORDS =
+                "pix recebido|me pagaram|gastei|paguei|pago|comprei|compra|despesa|recebi|ganhei|entrou|entrada|caiu|depositaram|deposito|boleto|debito|debitei|reais|real";
 
-    private static final Pattern NATURAL_ACCOUNT_PATTERN = Pattern.compile(
-            "\\b(?:na|no)\\s+([a-zA-Z][a-zA-Z0-9\\s]{1,30}?)(?=\\b(?:hoje|ontem|amanha|esse mes|este mes|mes passado|semana passada|ultimos 7 dias|e|,|\\?|$))"
-    );
-    private static final Pattern INSTALLMENT_PATTERN = Pattern.compile("\\b(?:parcelad[oa]\\s+em\\s+|em\\s+)(\\d{1,3})x\\b");
-    private static final Pattern INSTALLMENT_PURCHASE_AMOUNT_PATTERN = Pattern.compile(
-            "\\b(?:de|por|valor(?:\\s+de)?|parcelar)\\s+(\\d+[\\.,]?\\d{0,2})\\b(?!\\s*x\\b)"
-    );
+        private static final Pattern AMOUNT_PATTERN = Pattern.compile("\\b(\\d+[\\.,]?\\d{0,2})\\b(?!\\s*x\\b)");
 
-    public ParsedTelegramMessage parse(String messageText) {
-        if (messageText == null || messageText.isBlank()) {
-            return unknown(messageText);
+        private static final Pattern EXPLICIT_ACCOUNT_PATTERN = Pattern.compile(
+                "\\b(?:conta|cartao)\\s+(?:da|do|de)?\\s*([a-zA-Z0-9\\s]+?)(?=\\s*(?:\\b(?:"
+                        + ACCOUNT_BOUNDARY_WORDS
+                        + ")\\b|,|\\?|$))"
+        );
+
+        private static final Pattern NATURAL_ACCOUNT_PATTERN = Pattern.compile(
+                "\\b(?:na|no)\\s+([a-zA-Z][a-zA-Z0-9\\s]{1,30}?)(?=\\s*(?:\\b(?:"
+                        + ACCOUNT_BOUNDARY_WORDS
+                        + ")\\b|,|\\?|$))"
+        );
+
+        private static final Pattern INSTALLMENT_PATTERN = Pattern.compile("\\b(?:parcelad[oa]\\s+em\\s+|em\\s+)(\\d{1,3})x\\b");
+
+        private static final Pattern INSTALLMENT_PURCHASE_AMOUNT_PATTERN = Pattern.compile(
+                "\\b(?:de|por|valor(?:\\s+de)?|parcelar)\\s+(\\d+[\\.,]?\\d{0,2})\\b(?!\\s*x\\b)"
+        );
+
+        private static final Pattern TRANSACTION_NOISE_PATTERN = Pattern.compile(
+                "\\b(?:" + TRANSACTION_NOISE_WORDS + ")\\b"
+        );
+
+        private static final Pattern DATE_NOISE_PATTERN = Pattern.compile(
+                "\\b(?:" + DATE_NOISE_WORDS + ")\\b"
+        );
+
+        private static final Pattern AMOUNT_WITH_OPTIONAL_PREPOSITION_PATTERN = Pattern.compile(
+                "\\b(?:(?:de|por|valor(?:\\s+de)?)\\s+)?\\d+[\\.,]?\\d{0,2}\\b"
+        );
+
+        private static final Pattern TRAILING_DESCRIPTION_NOISE_PATTERN = Pattern.compile(
+                "\\b(?:de|do|da|dos|das|por|em)\\s*$"
+        );
+
+        private final TelegramDateRangeResolver telegramDateRangeResolver;
+        private final TelegramNaturalLanguageVocabulary telegramNaturalLanguageVocabulary;
+
+        public TelegramIntentService(
+                TelegramDateRangeResolver telegramDateRangeResolver,
+                TelegramNaturalLanguageVocabulary telegramNaturalLanguageVocabulary
+        ) {
+            this.telegramDateRangeResolver = telegramDateRangeResolver;
+            this.telegramNaturalLanguageVocabulary = telegramNaturalLanguageVocabulary;
         }
 
-        String normalized = telegramNaturalLanguageVocabulary.normalize(messageText);
+        public ParsedTelegramMessage parse(String messageText) {
+            if (messageText == null || messageText.isBlank()) {
+                return unknown(messageText);
+            }
 
-        if (isMonthAnalysisQuery(normalized)) {
-            ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
+            String normalized = telegramNaturalLanguageVocabulary.normalize(messageText);
 
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_MONTH_ANALYSIS,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    null,
-                    null,
-                    dateRange.startDate(),
-                    dateRange.endDate(),
-                    null,
-                    null,
-                    null
-            );
-        }
+            if (isMonthAnalysisQuery(normalized)) {
+                ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
 
-        if (isInstallmentCountQuery(normalized)) {
-            ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
-
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_INSTALLMENT_COUNT,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    null,
-                    null,
-                    dateRange.startDate(),
-                    dateRange.endDate(),
-                    null,
-                    null,
-                    null
-            );
-        }
-
-        if (isActiveInstallmentsQuery(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_ACTIVE_INSTALLMENTS,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-            );
-        }
-
-        if (isInstallmentRemainingQuery(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_INSTALLMENT_REMAINING,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    extractInstallmentQueryTarget(normalized),
-                    null
-            );
-        }
-
-        if (isInstallmentEndDateQuery(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_INSTALLMENT_END_DATE,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    null,
-                    null,
-                    null,
-                    null,
-                    null,
-                    extractInstallmentQueryTarget(normalized),
-                    null
-            );
-        }
-
-        if (isInstallmentPurchaseCapacityQuery(normalized)) {
-            BigDecimal totalAmount = extractInstallmentPurchaseAmount(normalized);
-            Integer totalInstallments = extractInstallmentCount(normalized);
-
-            if (totalAmount != null && totalInstallments != null && totalInstallments >= 2) {
                 return new ParsedTelegramMessage(
-                        TelegramIntentType.QUERY_INSTALLMENT_PURCHASE_CAPACITY,
+                        TelegramIntentType.QUERY_MONTH_ANALYSIS,
+                        null,
+                        null,
+                        LocalDate.now(),
+                        messageText,
+                        null,
+                        null,
+                        dateRange.startDate(),
+                        dateRange.endDate(),
+                        null,
+                        null,
+                        null
+                );
+            }
+
+            if (isInstallmentCountQuery(normalized)) {
+                ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
+
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.QUERY_INSTALLMENT_COUNT,
+                        null,
+                        null,
+                        LocalDate.now(),
+                        messageText,
+                        null,
+                        null,
+                        dateRange.startDate(),
+                        dateRange.endDate(),
+                        null,
+                        null,
+                        null
+                );
+            }
+
+            if (isActiveInstallmentsQuery(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.QUERY_ACTIVE_INSTALLMENTS,
                         null,
                         null,
                         LocalDate.now(),
@@ -148,372 +125,452 @@ public class TelegramIntentService {
                         null,
                         null,
                         null,
-                        totalInstallments,
                         null,
-                        totalAmount
+                        null,
+                        null
                 );
+            }
+
+            if (isInstallmentRemainingQuery(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.QUERY_INSTALLMENT_REMAINING,
+                        null,
+                        null,
+                        LocalDate.now(),
+                        messageText,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        extractInstallmentQueryTarget(normalized),
+                        null
+                );
+            }
+
+            if (isInstallmentEndDateQuery(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.QUERY_INSTALLMENT_END_DATE,
+                        null,
+                        null,
+                        LocalDate.now(),
+                        messageText,
+                        null,
+                        null,
+                        null,
+                        null,
+                        null,
+                        extractInstallmentQueryTarget(normalized),
+                        null
+                );
+            }
+
+            if (isInstallmentPurchaseCapacityQuery(normalized)) {
+                BigDecimal totalAmount = extractInstallmentPurchaseAmount(normalized);
+                Integer totalInstallments = extractInstallmentCount(normalized);
+
+                if (totalAmount != null && totalInstallments != null && totalInstallments >= 2) {
+                    return new ParsedTelegramMessage(
+                            TelegramIntentType.QUERY_INSTALLMENT_PURCHASE_CAPACITY,
+                            null,
+                            null,
+                            LocalDate.now(),
+                            messageText,
+                            null,
+                            null,
+                            null,
+                            null,
+                            totalInstallments,
+                            null,
+                            totalAmount
+                    );
+                }
+            }
+
+            if (isTransactionTotalQuery(normalized)) {
+                ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
+
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.QUERY_TRANSACTION_TOTAL,
+                        null,
+                        null,
+                        LocalDate.now(),
+                        messageText,
+                        extractCategoryName(normalized),
+                        extractAccountName(normalized),
+                        dateRange.startDate(),
+                        dateRange.endDate(),
+                        null,
+                        null,
+                        null
+                );
+            }
+
+            if (looksLikeInstallmentExpense(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.CREATE_INSTALLMENT_EXPENSE,
+                        extractAmount(normalized),
+                        extractInstallmentDescription(normalized),
+                        extractDate(normalized),
+                        messageText,
+                        extractCategoryName(normalized),
+                        extractAccountName(normalized),
+                        null,
+                        null,
+                        extractInstallmentCount(normalized),
+                        null,
+                        null
+                );
+            }
+
+            if (looksLikeExpense(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.CREATE_EXPENSE,
+                        extractAmount(normalized),
+                        extractDescriptionForTransaction(normalized),
+                        extractDate(normalized),
+                        messageText,
+                        extractCategoryName(normalized),
+                        extractAccountName(normalized),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                );
+            }
+
+            if (looksLikeIncome(normalized)) {
+                return new ParsedTelegramMessage(
+                        TelegramIntentType.CREATE_INCOME,
+                        extractAmount(normalized),
+                        extractDescriptionForTransaction(normalized),
+                        extractDate(normalized),
+                        messageText,
+                        extractCategoryName(normalized),
+                        extractAccountName(normalized),
+                        null,
+                        null,
+                        null,
+                        null,
+                        null
+                );
+            }
+
+            return unknown(messageText);
+        }
+
+        private ParsedTelegramMessage unknown(String messageText) {
+            return new ParsedTelegramMessage(
+                    TelegramIntentType.UNKNOWN,
+                    null,
+                    null,
+                    null,
+                    messageText,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+            );
+        }
+
+        private boolean isInstallmentPurchaseCapacityQuery(String text) {
+            boolean asksCapacity = text.contains("consigo")
+                    || text.contains("cabe no meu orcamento")
+                    || text.contains("cabe no orcamento")
+                    || text.contains("se eu parcelar");
+
+            return asksCapacity
+                    && (text.contains("compra") || text.contains("parcel"))
+                    && extractInstallmentCount(text) != null
+                    && extractInstallmentPurchaseAmount(text) != null;
+        }
+
+        private boolean isTransactionTotalQuery(String text) {
+            return text.contains("quanto gastei")
+                    || text.contains("quanto recebi")
+                    || text.contains("quanto entrou")
+                    || text.contains("total gasto")
+                    || text.contains("total recebido")
+                    || text.contains("gastei quanto")
+                    || text.contains("recebi quanto")
+                    || text.contains("entrou quanto");
+        }
+
+        private boolean isMonthAnalysisQuery(String text) {
+            return text.contains("analise")
+                    || text.contains("resumo financeiro");
+        }
+
+        private boolean looksLikeExpense(String text) {
+            return text.contains("gastei")
+                    || text.contains("paguei")
+                    || text.contains("comprei")
+                    || text.contains("despesa")
+                    || text.contains("pago")
+                    || text.contains("compra")
+                    || text.contains("boleto")
+                    || text.contains("debito")
+                    || text.contains("debitei")
+                    || text.contains("saiu da conta")
+                    || text.contains("saiu do banco");
+        }
+
+        private boolean looksLikeInstallmentExpense(String text) {
+            Integer installmentCount = extractInstallmentCount(text);
+
+            return looksLikeExpense(text)
+                    && installmentCount != null
+                    && installmentCount >= 2;
+        }
+
+        private boolean looksLikeIncome(String text) {
+            return text.contains("recebi")
+                    || text.contains("ganhei")
+                    || text.contains("entrou")
+                    || text.contains("entrada")
+                    || text.contains("caiu")
+                    || text.contains("depositaram")
+                    || text.contains("deposito")
+                    || text.contains("pix recebido")
+                    || text.contains("me pagaram");
+        }
+
+        private BigDecimal extractAmount(String text) {
+            Matcher matcher = AMOUNT_PATTERN.matcher(text);
+
+            if (!matcher.find()) {
+                return null;
+            }
+
+            String value = matcher.group(1);
+
+            if (value.contains(",") && value.contains(".")) {
+                value = value.replace(".", "").replace(",", ".");
+            } else if (value.contains(",")) {
+                value = value.replace(",", ".");
+            }
+
+            return new BigDecimal(value);
+        }
+
+        private BigDecimal extractInstallmentPurchaseAmount(String text) {
+            Matcher matcher = INSTALLMENT_PURCHASE_AMOUNT_PATTERN.matcher(text);
+
+            if (!matcher.find()) {
+                return null;
+            }
+
+            String value = matcher.group(1);
+
+            if (value.contains(",") && value.contains(".")) {
+                value = value.replace(".", "").replace(",", ".");
+            } else if (value.contains(",")) {
+                value = value.replace(",", ".");
+            }
+
+            return new BigDecimal(value);
+        }
+
+        private String extractDescriptionForTransaction(String text) {
+            String normalized = telegramNaturalLanguageVocabulary.normalize(text);
+            String cleaned = normalized;
+
+            String extractedAccount = extractAccountName(normalized);
+            if (extractedAccount != null) {
+                String normalizedAccount = telegramNaturalLanguageVocabulary.normalize(extractedAccount);
+                cleaned = cleaned.replaceAll("\\bna\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
+                cleaned = cleaned.replaceAll("\\bno\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
+                cleaned = cleaned.replaceAll("\\bconta\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
+                cleaned = cleaned.replaceAll("\\bcartao\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
+            }
+
+            cleaned = TRANSACTION_NOISE_PATTERN.matcher(cleaned).replaceAll("");
+            cleaned = DATE_NOISE_PATTERN.matcher(cleaned).replaceAll("");
+
+            cleaned = cleaned
+                    .replaceAll("\\bparcelad[oa]\\s+em\\s+\\d{1,3}x\\b", "")
+                    .replaceAll("\\bem\\s+\\d{1,3}x\\b", "");
+
+            cleaned = AMOUNT_WITH_OPTIONAL_PREPOSITION_PATTERN.matcher(cleaned).replaceAll("");
+
+            cleaned = cleaned
+                    .replaceAll("\\b(?:da conta|do cartao|na conta|no cartao)\\b.*", "")
+                    .replaceAll("\\s+", " ")
+                    .trim();
+
+            cleaned = telegramNaturalLanguageVocabulary.stripLeadingDescriptionNoise(cleaned);
+            cleaned = TRAILING_DESCRIPTION_NOISE_PATTERN.matcher(cleaned).replaceAll("").trim();
+
+            if (cleaned.isBlank()) {
+                return null;
+            }
+
+            return cleaned;
+        }
+
+        private String extractInstallmentDescription(String text) {
+            String description = extractDescriptionForTransaction(text);
+
+            if (description == null || description.isBlank()) {
+                return "Despesa parcelada";
+            }
+
+            return description;
+        }
+
+        private Integer extractInstallmentCount(String text) {
+            Matcher matcher = INSTALLMENT_PATTERN.matcher(text);
+
+            if (!matcher.find()) {
+                return null;
+            }
+
+            try {
+                return Integer.valueOf(matcher.group(1));
+            } catch (NumberFormatException e) {
+                return null;
             }
         }
 
-        if (isTransactionTotalQuery(normalized)) {
-            ParsedDateRange dateRange = telegramDateRangeResolver.resolve(normalized);
+        public String extractInstallmentQueryTarget(String text) {
+            String normalized = telegramNaturalLanguageVocabulary.normalize(text);
 
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.QUERY_TRANSACTION_TOTAL,
-                    null,
-                    null,
-                    LocalDate.now(),
-                    messageText,
-                    extractCategoryName(normalized),
-                    extractAccountName(normalized),
-                    dateRange.startDate(),
-                    dateRange.endDate(),
-                    null,
-                    null,
-                    null
-            );
+            String cleaned = normalized
+                    .replaceAll("\\bquando acaba o parcelamento\\b", "")
+                    .replaceAll("\\bquando termina o parcelamento\\b", "")
+                    .replaceAll("\\bquando acaba minha parcela\\b", "")
+                    .replaceAll("\\bquando acaba meu parcelamento\\b", "")
+                    .replaceAll("\\bquando termina minha parcela\\b", "")
+                    .replaceAll("\\bquando termina meu parcelamento\\b", "")
+                    .replaceAll("\\bquando termina a parcela\\b", "")
+                    .replaceAll("\\bquando acaba a parcela\\b", "")
+                    .replaceAll("\\bquando termina parcela\\b", "")
+                    .replaceAll("\\bquando acaba parcela\\b", "")
+                    .replaceAll("\\bquantas parcelas faltam\\b", "")
+                    .replaceAll("\\bquantas faltam\\b", "")
+                    .replaceAll("\\bfaltam quantas parcelas\\b", "")
+                    .replaceAll("\\bquantas parcelas restam\\b", "")
+                    .replaceAll("\\brestam quantas parcelas\\b", "")
+                    .replaceAll("\\b(parcelamento|parcela|parcelas)\\b", "")
+                    .replaceAll("\\b(do|da|de|meu|minha|o|a)\\b", "")
+                    .replaceAll("[\\?]", "")
+                    .replaceAll("\\s+", " ")
+                    .trim();
+
+            cleaned = telegramNaturalLanguageVocabulary.stripLeadingQueryTargetNoise(cleaned);
+            return cleaned.isBlank() ? null : cleaned;
         }
 
-        if (looksLikeInstallmentExpense(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.CREATE_INSTALLMENT_EXPENSE,
-                    extractAmount(normalized),
-                    extractInstallmentDescription(normalized),
-                    extractDate(normalized),
-                    messageText,
-                    extractCategoryName(normalized),
-                    extractAccountName(normalized),
-                    null,
-                    null,
-                    extractInstallmentCount(normalized),
-                    null,
-                    null
-            );
+        public String extractCategoryName(String text) {
+            String normalized = telegramNaturalLanguageVocabulary.normalize(text);
+            String accountName = extractAccountName(normalized);
+
+            if (accountName != null) {
+                String normalizedAccount = telegramNaturalLanguageVocabulary.normalize(accountName);
+                normalized = normalized.replaceAll("\\b(?:na|no|conta|cartao)\\s+" + Pattern.quote(normalizedAccount) + "\\b", " ");
+                normalized = normalized.replaceAll("\\b" + Pattern.quote(normalizedAccount) + "\\b", " ");
+            }
+
+            return telegramNaturalLanguageVocabulary.findCategoryName(normalized);
         }
 
-        if (looksLikeExpense(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.CREATE_EXPENSE,
-                    extractAmount(normalized),
-                    extractDescriptionForTransaction(normalized),
-                    extractDate(normalized),
-                    messageText,
-                    extractCategoryName(normalized),
-                    extractAccountName(normalized),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-            );
-        }
+        public String extractAccountName(String text) {
+            String explicitAccount = extractAccountByPattern(EXPLICIT_ACCOUNT_PATTERN, text);
+            if (explicitAccount != null) {
+                return explicitAccount;
+            }
 
-        if (looksLikeIncome(normalized)) {
-            return new ParsedTelegramMessage(
-                    TelegramIntentType.CREATE_INCOME,
-                    extractAmount(normalized),
-                    extractDescriptionForTransaction(normalized),
-                    extractDate(normalized),
-                    messageText,
-                    extractCategoryName(normalized),
-                    extractAccountName(normalized),
-                    null,
-                    null,
-                    null,
-                    null,
-                    null
-            );
-        }
+            String naturalAccount = extractAccountByPattern(NATURAL_ACCOUNT_PATTERN, text);
+            if (naturalAccount != null) {
+                return naturalAccount;
+            }
 
-        return unknown(messageText);
-    }
-
-    private ParsedTelegramMessage unknown(String messageText) {
-        return new ParsedTelegramMessage(
-                TelegramIntentType.UNKNOWN,
-                null,
-                null,
-                null,
-                messageText,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        );
-    }
-
-    private boolean isInstallmentPurchaseCapacityQuery(String text) {
-        boolean asksCapacity = text.contains("consigo")
-                || text.contains("cabe no meu orcamento")
-                || text.contains("cabe no orcamento")
-                || text.contains("se eu parcelar");
-
-        return asksCapacity
-                && (text.contains("compra") || text.contains("parcel"))
-                && extractInstallmentCount(text) != null
-                && extractInstallmentPurchaseAmount(text) != null;
-    }
-
-    private boolean isTransactionTotalQuery(String text) {
-        return text.contains("quanto gastei")
-                || text.contains("quanto recebi")
-                || text.contains("quanto entrou")
-                || text.contains("total gasto")
-                || text.contains("total recebido")
-                || text.contains("gastei quanto")
-                || text.contains("recebi quanto")
-                || text.contains("entrou quanto");
-    }
-
-    private boolean isMonthAnalysisQuery(String text) {
-        return text.contains("analise")
-                || text.contains("análise")
-                || text.contains("resumo financeiro");
-    }
-
-    private boolean looksLikeExpense(String text) {
-        return text.contains("gastei")
-                || text.contains("paguei")
-                || text.contains("comprei")
-                || text.contains("despesa");
-    }
-
-    private boolean looksLikeInstallmentExpense(String text) {
-        Integer installmentCount = extractInstallmentCount(text);
-
-        return looksLikeExpense(text)
-                && installmentCount != null
-                && installmentCount >= 2;
-    }
-
-    private boolean looksLikeIncome(String text) {
-        return text.contains("recebi")
-                || text.contains("ganhei")
-                || text.contains("entrou")
-                || text.contains("entrada");
-    }
-
-    private BigDecimal extractAmount(String text) {
-        Matcher matcher = AMOUNT_PATTERN.matcher(text);
-
-        if (!matcher.find()) {
             return null;
         }
 
-        String value = matcher.group(1);
+        private LocalDate extractDate(String text) {
+            LocalDate today = LocalDate.now();
 
-        if (value.contains(",") && value.contains(".")) {
-            value = value.replace(".", "").replace(",", ".");
-        } else if (value.contains(",")) {
-            value = value.replace(",", ".");
+            if (containsWord(text, "ontem") || containsWord(text, "ont")) {
+                return today.minusDays(1);
+            }
+
+            if (containsWord(text, "amanha")) {
+                return today.plusDays(1);
+            }
+
+            return today;
         }
 
-        return new BigDecimal(value);
-    }
+        private String extractAccountByPattern(Pattern pattern, String text) {
+            String normalized = telegramNaturalLanguageVocabulary.normalize(text);
+            Matcher matcher = pattern.matcher(normalized);
 
-    private BigDecimal extractInstallmentPurchaseAmount(String text) {
-        Matcher matcher = INSTALLMENT_PURCHASE_AMOUNT_PATTERN.matcher(text);
+            if (!matcher.find()) {
+                return null;
+            }
 
-        if (!matcher.find()) {
-            return null;
+            String account = DATE_NOISE_PATTERN.matcher(matcher.group(1)).replaceAll("").trim();
+            account = trimTrailingConnector(account);
+
+            if (account.isBlank()) {
+                return null;
+            }
+
+            return telegramNaturalLanguageVocabulary.resolveAccountName(account);
         }
 
-        String value = matcher.group(1);
-
-        if (value.contains(",") && value.contains(".")) {
-            value = value.replace(".", "").replace(",", ".");
-        } else if (value.contains(",")) {
-            value = value.replace(",", ".");
+        private String trimTrailingConnector(String text) {
+            return text.replaceAll("\\b(e|em|com)\\b\\s*$", "").trim();
         }
 
-        return new BigDecimal(value);
-    }
-
-    private String extractDescriptionForTransaction(String text) {
-        String normalized = telegramNaturalLanguageVocabulary.normalize(text);
-
-        String cleaned = normalized
-                .replaceAll("\\b(gastei|paguei|comprei|despesa|recebi|ganhei|entrou|entrada|reais|real)\\b", "")
-                .replaceAll("\\bpor\\b", "")
-                .replaceAll("\\b(hoje|ontem|amanha|mes|esse mes|este mes|mes passado|semana passada|ultimos 7 dias)\\b", "")
-                .replaceAll("\\bparcelad[oa]\\s+em\\s+\\d{1,3}x\\b", "")
-                .replaceAll("\\bem\\s+\\d{1,3}x\\b", "")
-                .replaceAll("(\\d+[\\.,]?\\d{0,2})", "")
-                .replaceAll("\\b(?:da conta|do cartao|na conta|no cartao)\\b.*", "")
-                .trim();
-
-        String extractedAccount = extractAccountName(normalized);
-        if (extractedAccount != null) {
-            String normalizedAccount = telegramNaturalLanguageVocabulary.normalize(extractedAccount);
-            cleaned = cleaned.replaceAll("\\bna\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
-            cleaned = cleaned.replaceAll("\\bno\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
-            cleaned = cleaned.replaceAll("\\bconta\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
-            cleaned = cleaned.replaceAll("\\bcartao\\s+" + Pattern.quote(normalizedAccount) + "\\b", "");
+        private boolean containsWord(String text, String word) {
+            Pattern pattern = Pattern.compile("(^|\\b)" + Pattern.quote(word) + "(\\b|$)");
+            return pattern.matcher(text).find();
         }
 
-        cleaned = telegramNaturalLanguageVocabulary.stripLeadingDescriptionNoise(
-                cleaned.replaceAll("\\s+", " ").trim()
-        );
-
-        if (cleaned.isBlank()) {
-            return null;
+        private boolean isInstallmentCountQuery(String text) {
+            return (text.contains("quantas parcelas") || text.contains("quantos parcelamentos"))
+                    && (text.contains("tenho")
+                    || text.contains("nesse mes")
+                    || text.contains("neste mes")
+                    || text.contains("esse mes")
+                    || text.contains("este mes")
+                    || text.contains("mes passado")
+                    || text.contains("hoje")
+                    || text.contains("ontem"));
         }
 
-        return cleaned;
-    }
-
-    private String extractInstallmentDescription(String text) {
-        String description = extractDescriptionForTransaction(text);
-
-        if (description == null || description.isBlank()) {
-            return "Despesa parcelada";
+        private boolean isActiveInstallmentsQuery(String text) {
+            return text.contains("parcelamentos ativos")
+                    || text.contains("parcelamento ativo")
+                    || text.contains("parcelas ativas")
+                    || text.contains("parcela ativa")
+                    || text.contains("tenho parcelamentos ativos");
         }
 
-        return description;
-    }
-
-    private Integer extractInstallmentCount(String text) {
-        Matcher matcher = INSTALLMENT_PATTERN.matcher(text);
-
-        if (!matcher.find()) {
-            return null;
+        private boolean isInstallmentRemainingQuery(String text) {
+            return text.contains("quantas parcelas faltam")
+                    || text.contains("quantas faltam")
+                    || text.contains("faltam quantas parcelas")
+                    || text.contains("quantas parcelas restam")
+                    || text.contains("restam quantas parcelas");
         }
 
-        try {
-            return Integer.valueOf(matcher.group(1));
-        } catch (NumberFormatException e) {
-            return null;
+        private boolean isInstallmentEndDateQuery(String text) {
+            return text.contains("quando acaba o parcelamento")
+                    || text.contains("quando termina o parcelamento")
+                    || text.contains("quando acaba minha parcela")
+                    || text.contains("quando acaba meu parcelamento")
+                    || text.contains("quando termina minha parcela")
+                    || text.contains("quando termina meu parcelamento")
+                    || text.contains("quando termina a parcela")
+                    || text.contains("quando acaba a parcela")
+                    || text.contains("quando termina parcela")
+                    || text.contains("quando acaba parcela");
         }
     }
-
-    public String extractInstallmentQueryTarget(String text) {
-        String normalized = telegramNaturalLanguageVocabulary.normalize(text);
-
-        String cleaned = normalized
-                .replaceAll("\\bquando acaba o parcelamento\\b", "")
-                .replaceAll("\\bquando termina o parcelamento\\b", "")
-                .replaceAll("\\bquando acaba minha parcela\\b", "")
-                .replaceAll("\\bquando acaba meu parcelamento\\b", "")
-                .replaceAll("\\bquando termina minha parcela\\b", "")
-                .replaceAll("\\bquando termina meu parcelamento\\b", "")
-                .replaceAll("\\bquantas parcelas faltam\\b", "")
-                .replaceAll("\\bquantas faltam\\b", "")
-                .replaceAll("\\bfaltam quantas parcelas\\b", "")
-                .replaceAll("\\bquantas parcelas restam\\b", "")
-                .replaceAll("\\brestam quantas parcelas\\b", "")
-                .replaceAll("\\b(parcelamento|parcela|parcelas)\\b", "")
-                .replaceAll("\\b(do|da|de|meu|minha|o|a)\\b", "")
-                .replaceAll("[\\?]", "")
-                .replaceAll("\\s+", " ")
-                .trim();
-
-        cleaned = telegramNaturalLanguageVocabulary.stripLeadingQueryTargetNoise(cleaned);
-        return cleaned.isBlank() ? null : cleaned;
-    }
-
-    public String extractCategoryName(String text) {
-        String normalized = telegramNaturalLanguageVocabulary.normalize(text);
-        String accountName = extractAccountName(normalized);
-
-        if (accountName != null) {
-            String normalizedAccount = telegramNaturalLanguageVocabulary.normalize(accountName);
-            normalized = normalized.replaceAll("\\b(?:na|no|conta|cartao)\\s+" + Pattern.quote(normalizedAccount) + "\\b", " ");
-            normalized = normalized.replaceAll("\\b" + Pattern.quote(normalizedAccount) + "\\b", " ");
-        }
-
-        return telegramNaturalLanguageVocabulary.findCategoryName(normalized);
-    }
-
-    public String extractAccountName(String text) {
-        String explicitAccount = extractAccountByPattern(EXPLICIT_ACCOUNT_PATTERN, text);
-        if (explicitAccount != null) {
-            return explicitAccount;
-        }
-
-        String naturalAccount = extractAccountByPattern(NATURAL_ACCOUNT_PATTERN, text);
-        if (naturalAccount != null) {
-            return naturalAccount;
-        }
-
-        return null;
-    }
-
-    private LocalDate extractDate(String text) {
-        LocalDate today = LocalDate.now();
-
-        if (text.contains("ontem")) {
-            return today.minusDays(1);
-        }
-
-        if (text.contains("amanha")) {
-            return today.plusDays(1);
-        }
-
-        return today;
-    }
-
-    private String extractAccountByPattern(Pattern pattern, String text) {
-        String normalized = telegramNaturalLanguageVocabulary.normalize(text);
-        Matcher matcher = pattern.matcher(normalized);
-
-        if (!matcher.find()) {
-            return null;
-        }
-
-        String account = matcher.group(1)
-                .replaceAll("\\b(hoje|ontem|amanha|esse mes|este mes|mes passado|semana passada|ultimos 7 dias)\\b", "")
-                .trim();
-
-        account = trimTrailingConnector(account);
-
-        if (account.isBlank()) {
-            return null;
-        }
-
-        return telegramNaturalLanguageVocabulary.resolveAccountName(account);
-    }
-
-    private String trimTrailingConnector(String text) {
-        return text.replaceAll("\\b(e|em|com)\\b\\s*$", "").trim();
-    }
-
-    private boolean isInstallmentCountQuery(String text) {
-        return (text.contains("quantas parcelas") || text.contains("quantos parcelamentos"))
-                && (text.contains("tenho")
-                || text.contains("nesse mes")
-                || text.contains("neste mes")
-                || text.contains("esse mes")
-                || text.contains("este mes")
-                || text.contains("mes passado")
-                || text.contains("hoje")
-                || text.contains("ontem"));
-    }
-
-    private boolean isActiveInstallmentsQuery(String text) {
-        return text.contains("parcelamentos ativos")
-                || text.contains("parcelamento ativo")
-                || text.contains("parcelas ativas")
-                || text.contains("parcela ativa")
-                || text.contains("tenho parcelamentos ativos");
-    }
-
-    private boolean isInstallmentRemainingQuery(String text) {
-        return text.contains("quantas parcelas faltam")
-                || text.contains("quantas faltam")
-                || text.contains("faltam quantas parcelas")
-                || text.contains("quantas parcelas restam")
-                || text.contains("restam quantas parcelas");
-    }
-
-    private boolean isInstallmentEndDateQuery(String text) {
-        return text.contains("quando acaba o parcelamento")
-                || text.contains("quando termina o parcelamento")
-                || text.contains("quando acaba minha parcela")
-                || text.contains("quando acaba meu parcelamento")
-                || text.contains("quando termina minha parcela")
-                || text.contains("quando termina meu parcelamento");
-    }
-}

--- a/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramNaturalLanguageVocabulary.java
+++ b/financebot-telegram-bot/src/main/java/com/financebot/telegrambot/service/TelegramNaturalLanguageVocabulary.java
@@ -80,6 +80,11 @@ public class TelegramNaturalLanguageVocabulary {
         aliases.put("mercado", "Mercado");
         aliases.put("atacadao", "Mercado");
         aliases.put("atacado", "Mercado");
+        aliases.put("mercadinho", "Mercado");
+        aliases.put("extra", "Mercado");
+        aliases.put("carrefour", "Mercado");
+        aliases.put("assai", "Mercado");
+
         aliases.put("mcdonalds", "Alimentação");
         aliases.put("mc donalds", "Alimentação");
         aliases.put("restaurante", "Alimentação");
@@ -89,30 +94,72 @@ public class TelegramNaturalLanguageVocabulary {
         aliases.put("lanche", "Alimentação");
         aliases.put("pizza", "Alimentação");
         aliases.put("comida", "Alimentação");
-        aliases.put("combustivel", "Combustível");
-        aliases.put("gasolina", "Combustível");
-        aliases.put("shell", "Combustível");
-        aliases.put("posto", "Combustível");
-        aliases.put("etanol", "Combustível");
-        aliases.put("diesel", "Combustível");
+        aliases.put("padaria", "Alimentação");
+        aliases.put("hamburguer", "Alimentação");
+        aliases.put("hamburgueria", "Alimentação");
+        aliases.put("sushi", "Alimentação");
+        aliases.put("japones", "Alimentação");
+        aliases.put("acai", "Alimentação");
+        aliases.put("cafe", "Alimentação");
+        aliases.put("bebida", "Alimentação");
+
+        aliases.put("combustivel", "Transporte");
+        aliases.put("gasolina", "Transporte");
+        aliases.put("shell", "Transporte");
+        aliases.put("posto", "Transporte");
+        aliases.put("etanol", "Transporte");
+        aliases.put("diesel", "Transporte");
         aliases.put("transporte", "Transporte");
         aliases.put("uber", "Transporte");
-        aliases.put("99", "Transporte");
+        aliases.put("99 app", "Transporte");
+        aliases.put("99app", "Transporte");
+        aliases.put("99 pop", "Transporte");
+        aliases.put("99pop", "Transporte");
         aliases.put("taxi", "Transporte");
         aliases.put("onibus", "Transporte");
         aliases.put("metro", "Transporte");
+
         aliases.put("farmacia", "Saúde");
         aliases.put("saude", "Saúde");
         aliases.put("remedio", "Saúde");
         aliases.put("medico", "Saúde");
         aliases.put("consulta", "Saúde");
+        aliases.put("academia", "Saúde");
+        aliases.put("dentista", "Saúde");
+        aliases.put("hospital", "Saúde");
+        aliases.put("exame", "Saúde");
+
         aliases.put("moradia", "Moradia");
         aliases.put("aluguel", "Moradia");
         aliases.put("condominio", "Moradia");
+        aliases.put("internet", "Moradia");
+        aliases.put("luz", "Moradia");
+        aliases.put("agua", "Moradia");
+        aliases.put("energia", "Moradia");
+        aliases.put("iptu", "Moradia");
+
+        aliases.put("netflix", "Lazer");
+        aliases.put("spotify", "Lazer");
+        aliases.put("cinema", "Lazer");
+        aliases.put("game", "Lazer");
+        aliases.put("games", "Lazer");
+        aliases.put("videogame", "Lazer");
+        aliases.put("playstation", "Lazer");
+        aliases.put("xbox", "Lazer");
+        aliases.put("nintendo", "Lazer");
+        aliases.put("steam", "Lazer");
+
         aliases.put("salario", "Salário");
+
         aliases.put("freela", "Freelance");
         aliases.put("freelance", "Freelance");
+
         aliases.put("outros", "Outros");
+        aliases.put("presente", "Outros");
+        aliases.put("roupa", "Outros");
+        aliases.put("tenis", "Outros");
+        aliases.put("celular", "Outros");
+        aliases.put("iphone", "Outros");
         return aliases;
     }
 


### PR DESCRIPTION
## Objetivo

Promover para a `main` as melhorias de interpretação determinística de mensagens naturais do Telegram, já integradas e validadas na branch `develop`.

## Alterações realizadas

- Expandido o vocabulário de categorias e contas usado pelo parser do Telegram.
- Melhorada a detecção de intenções de despesa e receita.
- Centralizados termos e padrões de limpeza do parser em constantes para facilitar manutenção.
- Melhorada a limpeza da descrição de transações interpretadas pelo Telegram, evitando sobras como `iphone de`.
- Melhorada a interpretação de consultas sobre término de parcelamentos.
- Melhorada a resolução de períodos como hoje, ontem, semana atual, últimos 7 dias e últimos 30 dias.
- Atualizado o `CHANGELOG.md` com as melhorias do parser no bloco `[Unreleased]`.

## Tipo de mudança

- [x] Feature
- [ ] Bugfix
- [x] Refatoração
- [ ] Testes
- [x] Documentação
- [ ] Configuração/infra

## Checklist de qualidade

- [x] O PR tem escopo pequeno e claro
- [ ] Executei `./mvnw clean verify`
- [ ] Os testes automatizados passaram
- [ ] Rodei análise local no SonarQube quando houve alteração relevante
- [ ] O Quality Gate continua aprovado quando houve análise SonarQube
- [ ] Não introduzi novas issues críticas de Security ou Reliability
- [ ] Mantive ou aumentei a cobertura de New Code quando houve código novo
- [x] Atualizei o `CHANGELOG.md` quando necessário
- [ ] Atualizei o `README.md` ou documentação quando necessário
- [x] Verifiquei que não foram adicionados tokens, senhas ou secrets

## Evidências

- Merge realizado previamente na branch `develop`.
- Parser ajustado para interpretar melhor mensagens como:
  - `gastei 50 na padaria`
  - `paguei 120 de internet`
  - `recebi 1200 de salário`
  - `comprei um iphone de 6000 parcelado em 10x`
  - `quando termina a parcela do iphone?`
  - `quanto gastei essa semana?`
  - `quanto gastei nos últimos 30 dias?`

## Testes realizados

- [x] `./mvnw clean verify`
- [ ] Testes unitários específicos
- [ ] Teste manual
- [ ] Análise SonarQube local
- [ ] Não se aplica

## Issue relacionada

Closes #74